### PR TITLE
Fix typos in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@
 LMQL is a query language for large language models (LLMs). It facilitates LLM interaction by combining the benefits of natural language prompting with the expressiveness of Python. With only a few lines of LMQL code, users can express advanced, multi-part and tool-augmented LM queries, which then are optimized by the LMQL runtime to run efficiently as part of the LM decoding loop.
 
 ![lmql-overview](https://user-images.githubusercontent.com/17903049/222918379-84a00b9a-1ef0-45bf-9384-15a20f2874f0.png)
+
 <p align="center">Example of a simple LMQL program.</p>
 
 
@@ -35,7 +36,7 @@ To install the latest version of LMQL run the following command with Python >=3.
 pip install lmql
 ```
 
-**Local GPU Support:** If you want to run models on a local GPU, make sure to install LMQL in an environment with a GPU-enabled installation of PyTorch >= 1.11 (cf. https://pytorch.org/get-started/locally/). 
+**Local GPU Support:** If you want to run models on a local GPU, make sure to install LMQL in an environment with a GPU-enabled installation of PyTorch >= 1.11 (cf. https://pytorch.org/get-started/locally/).
 
 ### Running LMQL Programs
 
@@ -45,7 +46,7 @@ After installation, you can launch the LMQL playground IDE with the following co
 lmql playground
 ```
 
-> Using the LMQL playground requires an installation of Node.js. If you are in a conda-managed environment you can install node.js via `conda install nodejs=14.20 -c conda-forge`. Otherwise, please see the offical Node.js website https://nodejs.org/en/download/ for instructions how to install it on your system.
+> Using the LMQL playground requires an installation of Node.js. If you are in a conda-managed environment you can install node.js via `conda install nodejs=14.20 -c conda-forge`. Otherwise, please see the official Node.js website https://nodejs.org/en/download/ for instructions how to install it on your system.
 
 This launches a browser-based playground IDE, including a showcase of many exemplary LMQL programs. If the IDE does not launch automatically, go to `http://localhost:3000`.
 
@@ -79,7 +80,7 @@ source scripts/activate-dev.sh
 
 ### Development without GPU
 
-This section outlines how to setup an LMQL development environment without local GPU support. Note that LMQL without local GPU support only supports the use of API-integrated models like `openai/text-davinci-003`. Please see the OpenAI API documentation (https://platform.openai.com/docs/models/gpt-3-5) to learn more about the set of available models. 
+This section outlines how to setup an LMQL development environment without local GPU support. Note that LMQL without local GPU support only supports the use of API-integrated models like `openai/text-davinci-003`. Please see the OpenAI API documentation (https://platform.openai.com/docs/models/gpt-3-5) to learn more about the set of available models.
 
 To setup a `conda` environment for LMQL with GPU support, run the following commands:
 

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -8,7 +8,7 @@ To install the latest version of LMQL locally, run the following command with Py
 pip install lmql
 ```
 
-**Local GPU Support:** If you want to run models on a local GPU, make sure to install LMQL in an environment with a GPU-enabled installation of PyTorch >= 1.11 (cf. [https://pytorch.org/get-started/locally/]()). 
+**Local GPU Support:** If you want to run models on a local GPU, make sure to install LMQL in an environment with a GPU-enabled installation of PyTorch >= 1.11 (cf. [https://pytorch.org/get-started/locally/]()).
 
 ## Running LMQL Programs
 
@@ -20,7 +20,7 @@ After installation, you can launch a local instance of the Playground IDE using 
 lmql playground
 ```
 
-> Using **the LMQL playground requires an installation of Node.js**. If you are in a conda-managed environment you can install node.js via `conda install nodejs=14.20 -c conda-forge`. Otherwise, please see the offical [Node.js website](https://nodejs.org/en/download/) for instructions on how to install it on your system.
+> Using **the LMQL playground requires an installation of Node.js**. If you are in a conda-managed environment you can install node.js via `conda install nodejs=14.20 -c conda-forge`. Otherwise, please see the official [Node.js website](https://nodejs.org/en/download/) for instructions on how to install it on your system.
 
 This launches a browser-based Playground IDE, including a showcase of many exemplary LMQL programs. If the IDE does not launch automatically, go to `http://localhost:3000`.
 
@@ -30,7 +30,7 @@ As an alternative to the playground, the command-line tool `lmql run` can be use
 
 **Python Integration**
 
-LMQL can also be used directly from within Python. To use LMQL in Python, you can import the `lmql` package, run query code via `lmql.run` or use a decorator `@lmql.query` for LMQL query functions. 
+LMQL can also be used directly from within Python. To use LMQL in Python, you can import the `lmql` package, run query code via `lmql.run` or use a decorator `@lmql.query` for LMQL query functions.
 
 For more details, please see the [Python Integration](./python/python.ipynb) chapter.
 
@@ -40,7 +40,7 @@ Note that when using local [🤗 Transformers](https://huggingface.co/transforme
 
 ## Configuring OpenAI API Credentials
 
-If you want to use OpenAI models, you have to configure your API credentials. To do so you can either define the `OPENAI_API_KEY` enviornment variable or create a file `api.env` in the active working directory, with the following contents.
+If you want to use OpenAI models, you have to configure your API credentials. To do so you can either define the `OPENAI_API_KEY` environment variable or create a file `api.env` in the active working directory, with the following contents.
 
 ```
 openai-org: <org identifier>

--- a/docs/source/language/models.md
+++ b/docs/source/language/models.md
@@ -30,7 +30,7 @@ Unfortunately, the OpenAI API Completions and Chat API are severely limited in t
 
 ### Configuring OpenAI API Credentials
 
-If you want to use OpenAI models, you have to configure your API credentials. To do so you can either define the `OPENAI_API_KEY` enviornment variable or create a file `api.env` in the active working directory, with the following contents.
+If you want to use OpenAI models, you have to configure your API credentials. To do so you can either define the `OPENAI_API_KEY` environment variable or create a file `api.env` in the active working directory, with the following contents.
 
 ```
 openai-org: <org identifier>
@@ -83,5 +83,3 @@ Now, when executing an LMQL query in the playground or via the CLI, you can simp
 #### Running The Playground Remotely
 
 If you would like to run the LMQL Playground itself remotely (e.g. for latency reasons), you can do so using a similar port forwarding/tunnel setup as described above. For this, make sure you client browser has access to the Playground server ports `3000` and `3004`.
-
-

--- a/docs/source/language/overview.md
+++ b/docs/source/language/overview.md
@@ -1,7 +1,7 @@
 # Overview
 
 LMQL is a declarative, SQL-like programming language for language model interaction. As an example consider the following query, demonstrating the basic syntax of LMQL:
- 
+
 ```{lmql}
 
 name::overview-query
@@ -10,7 +10,7 @@ argmax
    Q: What is the underlying sentiment of this review and why?
    A:[ANALYSIS]
    Based on this, the overall sentiment of the message can be considered to be[CLASSIFICATION]"""
-from 
+from
    "openai/text-davinci-003"
 where
    not "\n" in ANALYSIS and CLASSIFICATION in [" positive", " neutral", " negative"]
@@ -29,32 +29,37 @@ Overall, the query consists of four main clauses:
 1. **Decoder Clause** First, we specify the decoding algorithm to use for text generation. In this case we use `argmax` decoding, however, LMQL also support branching decoding algorithms like beam search. See [Decoders](./decoders.md) to learn more about this.
 
 2. **Prompt Clause**
-    ```python
-    """Review: We had a great stay. Hiking in the mountains was fabulous and the food is really good.
+
+   ```python
+   """Review: We had a great stay. Hiking in the mountains was fabulous and the food is really good.
    Q: What is the underlying sentiment of this review and why?
    A:[ANALYSIS]
    Based on this, the overall sentiment of the message can be considered to be[CLASSIFICATION]"""
    ```
-    In this part of the program, you specify your prompt. Here, we include the user review, as well as the two questions we want to ask the model. Template variables like `[ANALYSIS]` are automatically completed by the model. Apart from simple textual prompts, LMQL also support multi-part and scripted prompts. To learn more, see [Scripted Prompting](./scripted_prompts.md).
+
+   In this part of the program, you specify your prompt. Here, we include the user review, as well as the two questions we want to ask the model. Template variables like `[ANALYSIS]` are automatically completed by the model. Apart from simple textual prompts, LMQL also support multi-part and scripted prompts. To learn more, see [Scripted Prompting](./scripted_prompts.md).
 
 3. **Model Clause**
+
     ```python
     from "openai/text-davinci-003"
     ```
+
     Next, we specify what model we want to use for text generation. In this case, we use the language model `openai/text-davinci-003`. To learn more about the different models available in LMQL, see [Models](./models.md).
 
 4. **Constraint Clause**
+
     ```python
     not "\n" in ANALYSIS and CLASSIFICATION in [" positive", " neutral", " negative"]
     ```
+
     In this part of the query, users can specify logical, high-level constraints on the generated text.<br>
     
     Here, we specify two constraints: For `ANALYSIS` we constrain the model to not output any newlines, which prevents the model from outputting multiple lines, which could potentially breaking the prompt. For `CLASSIFICATION` we constrain the model to output one of the three possible values. Using these constraints allows us to decode a fitting answer from the model, where both the analysis and the classification are well-formed and in an expected format.
 
+   Without constraints, the prompt above could produce different final classifications, such as `good`, `bad`, or `neutral`. To handle this in an automated way, one would again have to employ some model of language understanding to parse the model's CLASSIFICATION result.
 
-    Without constraints, the prompt above could produce different final classifications, such as `good`, `bad`, or `neutral`. To handle this in an automated way, one would again have to employ some model of language understanding to parse the model's CLASSIFICATION result.
-
-    To learn more about the different types of constraints available in LMQL, see [Constraints](./constraints.md).
+   To learn more about the different types of constraints available in LMQL, see [Constraints](./constraints.md).
 
 ### Extracting More Information With Distributions
 
@@ -68,7 +73,7 @@ argmax
    Q: What is the underlying sentiment of this review and why?
    A:[ANALYSIS]
    Based on this, the overall sentiment of the message can be considered to be[CLASSIFICATION]"""
-from 
+from
    "openai/text-davinci-003"
 where
    not "\n" in ANALYSIS
@@ -89,9 +94,9 @@ P(CLASSIFICATION)
 
 **Distribution Clause**
 
-Instead of constraining `CLASSIFICATION` as part of the `where` clause, we now constrain in the `distribution` clause. In LMQL, the `distribution` clause is used to specify whether we want to additionally obtain the distribution over the possible values for a given variable. In this case, we want to obtain the distribution over the possible values for `CLASSIFICATION`. 
+Instead of constraining `CLASSIFICATION` as part of the `where` clause, we now constrain in the `distribution` clause. In LMQL, the `distribution` clause is used to specify whether we want to additionally obtain the distribution over the possible values for a given variable. In this case, we want to obtain the distribution over the possible values for `CLASSIFICATION`.
 
-In addition to using the model to perform the `ANALYSIS`, LMQL now also scores each of the individually provided values for `CLASSIFICATION` and normalizes the resulting sequence scores into a probability distribution `P(CLASSIFICATION)` (printed to the Terminal Ouput of the Playground or Standard Output of the CLI).
+In addition to using the model to perform the `ANALYSIS`, LMQL now also scores each of the individually provided values for `CLASSIFICATION` and normalizes the resulting sequence scores into a probability distribution `P(CLASSIFICATION)` (printed to the Terminal Output of the Playground or Standard Output of the CLI).
 
 Here, we can see that the model is indeed quite confident in its classification of the review as `positive`, with an overwhelming probability of `99.9%`.
 
@@ -130,6 +135,6 @@ What is it that they liked about their stay?⏎
 [FURTHER_ANALYSIS The reviewer liked the hiking in the mountains and the food.]
 ```
 
-As shown here, we can use the `if` statement to dynamically react to the model's output. In this case, we ask the model to provide a more detailed analysis of the review, depending on the overally positive, neutral, or negative sentiment of the review. All intermediate variables like `ANALYSIS`, `CLASSIFICATION` or `FURTHER_ANALYSIS` can be considered the output of query, and may be processed by an surrounding automated system. 
+As shown here, we can use the `if` statement to dynamically react to the model's output. In this case, we ask the model to provide a more detailed analysis of the review, depending on the overall positive, neutral, or negative sentiment of the review. All intermediate variables like `ANALYSIS`, `CLASSIFICATION` or `FURTHER_ANALYSIS` can be considered the output of query, and may be processed by an surrounding automated system.
 
 To learn more about the capabilities of such control-flow-guided prompts, see [Scripted Prompting](./scripted_prompts.md).

--- a/docs/source/language/scripted_prompts.md
+++ b/docs/source/language/scripted_prompts.md
@@ -5,7 +5,7 @@ In LMQL, prompts are not just static text, as they can also contain control flow
 **Packing List** For instance, let's say we want to generate a packing list. One way to do this would be the following query:
 
 ```{lmql}
-  
+
 name::list
 sample(temperature=0.8)
    "A few things not to forget when going to the sea (not travelling): \n"
@@ -73,10 +73,10 @@ A list of things not to forget when going to the sea (not travelling):
 -[THING A good pair of blue/gel saskaers]
 -[THING A good sun tanner]
 -[THING A good air freshener]
--[THING A good spot forwashing your hands]
+-[THING A good spot for washing your hands]
 -[THING A good spot for washing your feet]
 
-# print output: \['A good pair of blue/gel saskaers', 'A good sun tanner', 'A good air freshener', 'A good spot forwashing your hands', 'A good spot for washing your feet'\]
+# print output: \['A good pair of blue/gel saskaers', 'A good sun tanner', 'A good air freshener', 'A good spot for washing your hands', 'A good spot for washing your feet'\]
 ```
 
 Because we decode our list `THING` by `THING`, we can easily access the individual items, without having to think about parsing or validation. We just add them to a `backpack` list of things, which we then can process further.


### PR DESCRIPTION
Amazing library 👏🤩

This MR fixes some typos I've found reading the docs and going through the examples.

The word "travelling" (with two 'll') appears several times, I think it's also a typo, right? If so, I can open a second small MR to fix this too.

I also don't know what "saskaers" means in `docs/source/language/scripted_prompts.md`

Thanks!