### PR TITLE
Add 8-bit support on CUDA via HuggingFace's load_in_8bit

### DIFF
--- a/src/lmql/model/serve.py
+++ b/src/lmql/model/serve.py
@@ -173,6 +173,7 @@ class ModelProcessor:
 
     def run(self):
         dtype = self.state.dtype
+        load_in_8bit = dtype == "8bit"
         if dtype == "float16":
             dtype = torch.float16
         else:
@@ -184,7 +185,7 @@ class ModelProcessor:
             self.model = AutoModelForCausalLM.from_pretrained(self.model_identifier, torch_dtype=dtype, resume_download=True)
         else:
             print("Loading {} (Multi-GPU)".format(self.model_identifier))
-            self.model = AutoModelForCausalLM.from_pretrained(self.model_identifier, torch_dtype=dtype, resume_download=True, device_map="auto")
+            self.model = AutoModelForCausalLM.from_pretrained(self.model_identifier, torch_dtype=dtype, resume_download=True, load_in_8bit=load_in_8bit, device_map="auto")
         self.model.eval()
         
         print("Ready!".format(self.model_identifier))
@@ -451,7 +452,7 @@ if __name__ == "__main__":
     parser.add_argument("--host", type=str, default="localhost")
     parser.add_argument("--cuda", action="store_true", default=False)
     parser.add_argument("--cache", type=str, default=None)
-    parser.add_argument("--dtype", type=str, default="none")
+    parser.add_argument("--dtype", type=str, default="none", help="What format to load the model weights. Options: 'float16' (not available on all models), '8bit' (requires bitsandbytes)")
     parser.add_argument("--wait_until_ready", action="store_true", default=False, help="Whether the server should start only after the model and tokenizer have been loaded.")
     parser.add_argument("--num-tokenizer-processes", type=int, default=2, dest="num_tokenizer_processes")
     


### PR DESCRIPTION
Hello!

I use a relatively mid-range graphics card for my work, which with LMQL loading models at full precision meant I got better performance from CPU inference than I do from GPU inference. Half precision also doesn't work with the model I'd like to use.

This PR should provide 8bit support for those who opt in with `--dtype 8bit` under `serve_model`. I also took the liberty of adding a help string to that option. The `8bit` dtype only applies when loading with `--cuda`, otherwise it's entirely ignored (not passed to HuggingFace at all.)

Hope this helps others, too!