### PR TITLE
Fix dtype parsing

### DIFF
--- a/src/lmql/models/lmtp/utils.py
+++ b/src/lmql/models/lmtp/utils.py
@@ -5,7 +5,9 @@ def rename_model_args(model_args):
     cuda = model_args.pop("cuda", False)
     dtype = model_args.pop("dtype", None)
 
-    if dtype == "8bit":
+    if dtype == "4bit":
+        model_args["load_in_4bit"] = True
+    elif dtype == "8bit":
         model_args["load_in_8bit"] = True
     elif dtype is not None:
         model_args["torch_dtype"] = getattr(torch, dtype)

--- a/src/lmql/models/lmtp/utils.py
+++ b/src/lmql/models/lmtp/utils.py
@@ -1,18 +1,17 @@
+import torch
+
+
 def rename_model_args(model_args):
     cuda = model_args.pop("cuda", False)
     dtype = model_args.pop("dtype", None)
 
-    # parse dtype
-    if dtype is not None:
-        model_args["torch_dtype"] = dtype
-    
-    if dtype == "float16":
-        model_args["torch_dtype"] = torch.float16
-    elif dtype == "8bit":
-        model_args["load_in_8bit"] = dtype == "8bit"
+    if dtype == "8bit":
+        model_args["load_in_8bit"] = True
+    elif dtype is not None:
+        model_args["torch_dtype"] = getattr(torch, dtype)
 
     # parse cuda
     if cuda:
         model_args["device_map"] = "auto"
-    
+
     return model_args


### PR DESCRIPTION
This fixes the issue noted in #94 , as well as other `--dtype` arguments that may not have been parsed correctly.

- Ignore dtype model arg if `8bit` specified as `--dtype` argument (only set `load_in_8bit` instead)
- Use `getattr` to parse string value (turning `"float16"` into `torch.float16` etc.)