### PR TITLE
change tokenizer name

### DIFF
--- a/src/lmql/runtime/openai_integration.py
+++ b/src/lmql/runtime/openai_integration.py
@@ -995,7 +995,7 @@ def openai_model(model_identifier, endpoint=None, mock=False, **kwargs):
         def get_tokenizer(self):
             if self._tokenizer is None:
                 if not mock:
-                    self._tokenizer = load_tokenizer("gpt2")
+                    self._tokenizer = load_tokenizer("gpt3-tokenizer")
                 else:
                     self._tokenizer = load_tokenizer(self.model_identifier)
             self.served_model = self


### PR DESCRIPTION
When using synchronous lmql and an openai model fixes: 

```
AssertionError: OpenAI models are not compatible with HuggingFace tokenizers. 
Please use 'tiktoken' or 'gpt3_tokenizer' instead.
```