### PR TITLE
llama.cpp backend

### DIFF
--- a/docs/source/language/llama.cpp.md
+++ b/docs/source/language/llama.cpp.md
@@ -1,0 +1,56 @@
+# llama.cpp models
+
+LMQL also supports [llama.cpp](https://github.com/ggerganov/llama.cpp) as an inference backend, which can run efficiently on CPU-only machines. 
+
+Before using llama.cpp models, make sure you installed its Python bindings via `pip install llama-cpp-python`, in the same environment where you installed LMQL. Also make sure you first convert your model weights according to the [llama.cpp documentation](https://github.com/ggerganov/llama.cpp#prepare-data--run), to the `.bin` format.
+
+[Just like Transformers models](hf.md), you can load llama.cpp models either locally or via a long-lived `lmql serve-model` inference server.
+
+### Model Server
+
+To start a llama.cpp model server, you can run the following command:
+
+```bash
+lmql serve-model llama.cpp:<PATH TO WEIGHTS>.bin
+```
+
+This will launch an [LMTP inference endpoint](https://github.com/eth-sri/lmql/tree/main/src/lmql/models/lmtp) on `localhost:8080`, which can be used from LMQL with a query program like this:
+
+```{lmql}
+name::llama_remote
+
+argmax 
+    "Say 'this is a test':[RESPONSE]" 
+from 
+    "llama.cpp:<PATH TO WEIGHTS>.bin"
+where 
+    len(TOKENS(RESPONSE)) < 10
+```
+
+### Running Without a Model Server
+
+To load the llama.cpp from the Python process that executes your LMQL query, you can use the following syntax:
+
+```{lmql}
+name::llama_local
+
+argmax 
+    "Say 'this is a test':[RESPONSE]"
+from
+    "local:llama.cpp:<PATH TO WEIGHTS>.bin"
+where 
+    len(TOKENS(RESPONSE)) < 10
+```
+
+### Configuring the Llama(...) instance
+
+Any parameters passed to `lmql serve-model` and, when running locally, to `lmql.model(...)` will be passed to the `Llama(...)` constructor. 
+
+For example, to configure the `Llama(...)` instance to use a `n_ctx` value of 1024, you can run:
+
+```bash
+lmql serve-model llama.cpp:<PATH TO WEIGHTS>.bin --n_ctx 1024
+```
+
+Or, when running locally, you can use `lmql.model("local:llama.cpp:<PATH TO WEIGHTS>.bin", n_ctx=1024)`.
+

--- a/docs/source/language/models.md
+++ b/docs/source/language/models.md
@@ -10,4 +10,5 @@ Due to the modular design of LMQL, it is easy to add support for new models and 
 openai.md
 azure.md
 hf.md
+llama.cpp.md
 ```

--- a/src/lmql/models/lmtp/backends/__init__.py
+++ b/src/lmql/models/lmtp/backends/__init__.py
@@ -1,11 +1,17 @@
 # always available
+from lmql.models.lmtp.backends.lmtp_model import LMTPModel
+
+# uniform random model
 import lmql.models.lmtp.backends.random_model
 
 # only available with 'transformers' package
 try:
     import transformers
-    import lmql.models.lmtp.backends.transformers
+    import lmql.models.lmtp.backends.transformers_model
 except:
     pass
 
-from lmql.models.lmtp.backends.lmtp_model import LMTPModel
+# only available with llama.cpp python bindings
+@LMTPModel.register("llama.cpp", module_dependencies=["llama_cpp"])
+def _llama_cpp_importer():
+    import lmql.models.lmtp.backends.llama_cpp_model

--- a/src/lmql/models/lmtp/backends/__main__.py
+++ b/src/lmql/models/lmtp/backends/__main__.py
@@ -1,0 +1,24 @@
+import sys
+import numpy as np
+
+from lmql.models.lmtp.backends import LMTPModel
+from lmql.models.lmtp.lmtp_scheduler import TokenStreamer
+from lmql.runtime.tokenizer import load_tokenizer
+
+import transformers
+
+# simple 'main' for testing backends
+if __name__ == "__main__":
+    backend = sys.argv[1]
+    model: LMTPModel = LMTPModel.load(backend)
+    t = load_tokenizer("huggyllama/llama-7b")
+
+    s = sys.argv[2]
+    input_ids = [t.bos_token_id] + t(s)["input_ids"]
+
+    class DebugStreamer:
+        def __call__(self, tokens, scores):
+            print(t.decode(tokens))
+            return False
+
+    model.generate(np.array(input_ids), np.ones_like(input_ids), 1.0, 10, None, DebugStreamer())

--- a/src/lmql/models/lmtp/backends/llama_cpp_model.py
+++ b/src/lmql/models/lmtp/backends/llama_cpp_model.py
@@ -1,0 +1,93 @@
+from typing import Tuple
+
+import numpy as np
+from llama_cpp import Llama, LlamaTokenizer
+
+import lmql.utils.nputil as nputil
+from lmql.models.lmtp.backends.lmtp_model import (LMTPModel, LMTPModelResult,
+                                                  TokenStreamer)
+
+class LlamaCppModel(LMTPModel):
+    def __init__(self, model_identifier, **kwargs):
+        self.model_identifier = model_identifier
+        self.kwargs = kwargs
+
+        print("[Loading llama.cpp model from", self.model_identifier, "]", flush=True)
+        self.llm = Llama(model_path=model_identifier.strip("llama.cpp:"), **kwargs)
+
+    def eos_token_id(self):
+        return 2
+
+    # def score(self, input_ids: torch.LongTensor, attention_mask: torch.LongTensor, **model_kwargs) -> Tuple[torch.FloatTensor, torch.FloatTensor]:
+    #     return super().score(input_ids, attention_mask, **model_kwargs)
+    
+    def generate(self, input_ids, attention_mask, 
+                 temperature: float, max_new_tokens: int, 
+                 bias_tensor, streamer: TokenStreamer) -> LMTPModelResult:
+        token_scores = []
+        sequence = []
+
+        input_ids = input_ids.reshape(-1).tolist()
+
+        def llama_streamer(tokens, scores):
+            nonlocal token_scores, sequence
+            scores = np.array(scores)
+            scores = nputil.log_softmax(scores, axis=-1)
+            token_scores.append(scores)
+            return False
+
+        logits_processor = self.logits_processors(bias_tensor) if bias_tensor is not None else None
+
+        print(input_ids, flush=True)
+
+        for i, token in zip(range(max_new_tokens), self.llm.generate(input_ids, max_new_tokens, 
+                                                            temp=temperature,
+                                                            stopping_criteria=llama_streamer, 
+                                                            logits_processor=logits_processor)):
+            sequence += [token]
+            sq_ar = np.array(sequence)
+            ts_ar = np.stack(token_scores, axis=0)
+            streamer(sq_ar.reshape(1, *sq_ar.shape), ts_ar.reshape(-1, 1, *ts_ar.shape[1:]))
+        
+        ts_ar = np.stack(token_scores, axis=0)
+        sq_ar = np.array(sequence)
+
+        return LMTPModelResult(
+            sequences=sq_ar.reshape(1, *sq_ar.shape),
+            scores=ts_ar.reshape(-1, 1, *ts_ar.shape[1:])
+        )
+
+    def logits_processors(self, logit_biases):
+        bias_tensors = None
+        make_bias_tensor = self.make_bias_tensor
+        
+        if len(logit_biases) == 0:
+            return []
+
+        class BatchLogitsProcessor:
+            def __call__(self, input_ids, scores):
+                nonlocal bias_tensors
+
+                scores = np.array(scores)
+
+                if bias_tensors is None:
+                    bias_tensors = np.array(make_bias_tensor(logit_biases, scores.shape[-1]))
+
+                return (scores + bias_tensors).reshape(-1)
+        
+        return BatchLogitsProcessor()
+
+LMTPModel.registry["llama.cpp"] = LlamaCppModel
+
+if __name__ == "__main__":
+    from transformers import AutoTokenizer
+   
+    llm = Llama("/Users/luca/Developer/llama.cpp/models/7B/ggml-model-q4_0.bin")
+    s = "Say this is a test:"
+    tokenizer = AutoTokenizer.from_pretrained("huggyllama/llama-7b")
+    ids = tokenizer(s)["input_ids"]
+    print(ids)
+
+    for token in llm.generate(ids, 120, temp=0.0):
+        ids += [token]
+        print(tokenizer.decode(ids))

--- a/src/lmql/models/lmtp/backends/lmtp_model.py
+++ b/src/lmql/models/lmtp/backends/lmtp_model.py
@@ -85,7 +85,10 @@ class LMTPModel:
 
         On each new produced token, invokes streamer(input_ids, np.ndarray, scores: List[np.ndarray]) 
         where input_ids is the batch of continued sequences of 'input_ids' and scores[-1] is the current
-        token (logprob) distribution.
+        token (logprob) distribution. 
+        
+        streamer() is not invoked for the last token, which is automatically streamed by the calling 
+        code, extracting token and score from the returned LMTPModelResult.
         """
         pass
 

--- a/src/lmql/models/lmtp/backends/transformers_model.py
+++ b/src/lmql/models/lmtp/backends/transformers_model.py
@@ -16,6 +16,8 @@ class TransformersLLM(LMTPModel):
         print("[", self.model_identifier, " ready on device ", self.model.device, 
         flush=True, sep="", end="]\n")
 
+        self.max_batch_size = kwargs.get("batch_size", 8)
+
     @property
     def eos_token_id(self):
         return self.model.config.eos_token_id

--- a/src/lmql/models/lmtp/lmtp_async.py
+++ b/src/lmql/models/lmtp/lmtp_async.py
@@ -6,7 +6,7 @@ asynchronously in the same process.
 import asyncio
 import pickle
 
-from .scheduler import TokenSession, Scheduler
+from .lmtp_scheduler import TokenSession, Scheduler
 from .errors import LMTPStreamError
 
 class LMTPAsyncTransport:

--- a/src/lmql/models/lmtp/lmtp_dcmodel.py
+++ b/src/lmql/models/lmtp/lmtp_dcmodel.py
@@ -85,7 +85,7 @@ class LMTPModel(DcModel):
         tokens = [t for t, _ in top_entries]
         scores = [s for _, s in top_entries]
         edge_type = ["top-{}".format(i+1) for i in range(len(top_entries))]
-        
+
         # for non argmax sampling modes, add the sampled token
         if sampling_mode != "top-1":
             tokens = [payload["token"]] + tokens
@@ -93,6 +93,11 @@ class LMTPModel(DcModel):
             edge_type = [sampling_mode] + edge_type
 
         tokens = self.tokenizer.decode_bytes(tokens)
+
+        # replace top-1 with payload["token"] if sampling mode is top-1
+        if sampling_mode == "top-1":
+            edge_type[0] = "top-1"
+            tokens[0] = self.tokenizer.decode_bytes([payload["token"]])
 
         return (s, tokens, scores, edge_type, {})
 

--- a/src/lmql/models/lmtp/lmtp_inference_server.py
+++ b/src/lmql/models/lmtp/lmtp_inference_server.py
@@ -13,7 +13,7 @@ import json
 import aiohttp
 from aiohttp import web
 
-from .scheduler import *
+from .lmtp_scheduler import *
 
 class LMTPWebSocketTransport:
     """

--- a/src/lmql/models/lmtp/lmtp_scheduler.py
+++ b/src/lmql/models/lmtp/lmtp_scheduler.py
@@ -137,7 +137,7 @@ class TokenStreamer:
             token_score = last_scores[i][last_tokens[i]]
 
             top_logprobs = {
-                last_tokens[i]: float(token_score.item()),
+                int(last_tokens[i]): float(token_score.item()),
                 **{int(token.item()): float(logprob.item()) for logprob, token in zip(logprobs, tokens)}
             }
 

--- a/src/lmql/models/lmtp/lmtp_scheduler.py
+++ b/src/lmql/models/lmtp/lmtp_scheduler.py
@@ -120,7 +120,7 @@ class TokenStreamer:
         
         last_tokens = input_ids[:, -1]
         last_scores = scores[-1]
-        
+
         max_num_top_logprobs = max([c.kwargs.get("top_logprobs", 1) for c in self.batch.calls])
 
         if not nputil.is_array(last_tokens):
@@ -130,10 +130,16 @@ class TokenStreamer:
 
         # for each sample get top logprobs
         all_logprobs, all_indices  = nputil.topk(last_scores, max_num_top_logprobs, sorted=True, axis=-1)
+
         for i in range(batch_size):
             logprobs = all_logprobs[i]
             tokens = all_indices[i]
             token_score = last_scores[i][last_tokens[i]]
+
+            top_logprobs = {
+                last_tokens[i]: float(token_score.item()),
+                **{int(token.item()): float(logprob.item()) for logprob, token in zip(logprobs, tokens)}
+            }
 
             num_top_logprobs = self.batch.calls[i].kwargs.get("top_logprobs", 1)
             logprobs = logprobs[:num_top_logprobs]
@@ -144,11 +150,9 @@ class TokenStreamer:
                 "stream_id": self.batch.calls[i].stream_id,
                 "logprob": float(token_score.item()),
                 "finish_reason": ("stop" if last_tokens[i].item() == self.eos_token_id else "length" if last else None),
-                "top_logprobs": {
-                    int(token.item()): float(logprob.item()) for logprob, token in zip(logprobs, tokens)
-                }
+                "top_logprobs": top_logprobs
             }
-
+            
             self.batch.calls[i].put(token_payload)
 
 class Scheduler:
@@ -180,7 +184,7 @@ class Scheduler:
     def put(self, call: GenerateCall):
         self.queue.put(call)
 
-    def batches(self):
+    def batches(self, max_batch_size=8):
         start = time.time()
         calls = []
         # get as many calls from the queue as possible within 0.1 seconds
@@ -194,7 +198,17 @@ class Scheduler:
         for c in calls:
             mode = c.generation_mode()
             batches_by_mode.setdefault(mode, []).append(c)
-        return batches_by_mode.values()
+        
+        # split batches that are too large
+        fitting_batches = []
+        for mode, batches in batches_by_mode.items():
+            if len(batches) > max_batch_size:
+                for i in range(0, len(batches), max_batch_size):
+                    fitting_batches.append(batches[i:i+max_batch_size])
+            else:
+                fitting_batches.append(batches)
+
+        return fitting_batches
 
     async def async_worker(self):
         """
@@ -236,7 +250,7 @@ class Scheduler:
             self.process_batch(model)
 
     def process_batch(self, model):
-        for batch in self.batches():
+        for batch in self.batches(model.max_batch_size):
             try:
                 b = GenerateBatch.from_calls(batch)
                 

--- a/src/lmql/models/lmtp/lmtp_serve.py
+++ b/src/lmql/models/lmtp/lmtp_serve.py
@@ -116,6 +116,15 @@ options:
                 assert next_argument_name is not None
                 if arg == "True": arg = True
                 elif arg == "False": arg = False
+                else:
+                    try:
+                        arg = int(arg)
+                    except:
+                        try:
+                            arg = float(arg)
+                        except:
+                            arg = str(arg)
+
 
                 kwargs[next_argument_name] = arg
                 next_argument_name = None

--- a/src/lmql/models/model.py
+++ b/src/lmql/models/model.py
@@ -41,6 +41,11 @@ def inprocess(model_name, use_existing_configuration=False, **kwargs):
     # extract/reassign renamed like 'cuda'
     kwargs = rename_model_args(kwargs)
 
+    # special case for 'llama.cpp'
+    if model_name.startswith("llama.cpp:"):
+        # kwargs["async_transport"] = True
+        kwargs["tokenizer"] = "huggyllama/llama-7b"
+
     if "endpoint" in kwargs:
         print("info: 'endpoint' argument is ignored for inprocess=True/local: models.")
 

--- a/src/lmql/runtime/interpreter.py
+++ b/src/lmql/runtime/interpreter.py
@@ -216,7 +216,7 @@ class PromptInterpreter:
 
         if model_name.model is not None:
             model_object = model_name.model
-            # if model_object is a type reference, we can use the model_identifier
+            # if model_object is a type reference, instantiate it
             if callable(model_object):
                 model_object = model_object()
 

--- a/src/lmql/runtime/model_registry.py
+++ b/src/lmql/runtime/model_registry.py
@@ -1,4 +1,4 @@
-from lmql.models.model import model, LMQLModel, inprocess
+from lmql.models.model import LMQLModel, inprocess
 import os
 
 model_name_aliases = {
@@ -63,8 +63,8 @@ def resolve(model_name, endpoint=None, **kwargs):
             kwargs["inprocess"] = True
             kwargs["async_transport"] = True
 
+        # special case for 'llama.cpp'
         if model_name.startswith("llama.cpp:"):
-            kwargs["inprocess"] = True
             # kwargs["async_transport"] = True
             kwargs["tokenizer"] = "huggyllama/llama-7b"
 

--- a/src/lmql/runtime/model_registry.py
+++ b/src/lmql/runtime/model_registry.py
@@ -63,6 +63,11 @@ def resolve(model_name, endpoint=None, **kwargs):
             kwargs["inprocess"] = True
             kwargs["async_transport"] = True
 
+        if model_name.startswith("llama.cpp:"):
+            kwargs["inprocess"] = True
+            # kwargs["async_transport"] = True
+            kwargs["tokenizer"] = "huggyllama/llama-7b"
+
         # determine endpoint URL
         if endpoint is None:
             endpoint = "localhost:8080"

--- a/src/lmql/ui/playground/src/App.jsx
+++ b/src/lmql/ui/playground/src/App.jsx
@@ -576,6 +576,7 @@ function ModelSelection() {
       {"name": "gpt2", "note": "🤗 Tranformers", inprocess: true},
       {"name": "gpt2-medium", "note": "🤗 Tranformers", inprocess: true},
       {"name": "facebook/opt-350m", "note": "🤗 Tranformers", inprocess: true},
+      {"name": "llama.cpp:<PATH>/llama-7b.bin", "note": "🦙 llama.cpp", inprocess: true},
     ]).concat(PREDEFINED["Other Suggestions"])
   }
 


### PR DESCRIPTION
This PR adds a llama.cpp LMTP backend for use in LMQL. It also adds a chapter to the documentation on how to use llama.cpp models.