### PR TITLE
Add support for GPTQ quantization

### DIFF
--- a/src/lmql/models/lmtp/backends/transformers_model.py
+++ b/src/lmql/models/lmtp/backends/transformers_model.py
@@ -1,4 +1,3 @@
-from transformers import AutoModelForCausalLM
 from typing import Tuple
 import torch
 from lmql.models.lmtp.backends.lmtp_model import LMTPModel, LMTPModelResult, TokenStreamer
@@ -9,9 +8,14 @@ class TransformersLLM(LMTPModel):
         self.model_identifier = model_identifier
         self.model_args = kwargs
 
-        print("[Loading", self.model_identifier, "with", f"AutoModelForCausalLM.from_pretrained({self.model_identifier}, {str(self.model_args)[1:-1]})]", flush=True)
-        
-        self.model = AutoModelForCausalLM.from_pretrained(self.model_identifier, **kwargs)
+        if self.model_args.pop("loader", None) == "auto-gptq":
+            from auto_gptq import AutoGPTQForCausalLM
+            print("[Loading", self.model_identifier, "with", f"AutoGPTQForCausalLM.from_quantized({self.model_identifier}, {str(self.model_args)[1:-1]})]", flush=True)
+            self.model = AutoGPTQForCausalLM.from_quantized(self.model_identifier, **self.model_args)
+        else:
+            from transformers import AutoModelForCausalLM
+            print("[Loading", self.model_identifier, "with", f"AutoModelForCausalLM.from_pretrained({self.model_identifier}, {str(self.model_args)[1:-1]})]", flush=True)
+            self.model = AutoModelForCausalLM.from_pretrained(self.model_identifier, **self.model_args)
         
         print("[", self.model_identifier, " ready on device ", self.model.device, 
         flush=True, sep="", end="]\n")

--- a/src/lmql/models/lmtp/lmtp_serve.py
+++ b/src/lmql/models/lmtp/lmtp_serve.py
@@ -5,7 +5,7 @@ Command Line Interface for lmtp_inference_server.py.
 from .lmtp_inference_server import *
 from .utils import rename_model_args
 
-def serve(model_name, host="localhost", port=8080, cuda=False, dtype=None, static=False, **kwargs):
+def serve(model_name, host="localhost", port=8080, cuda=False, dtype=None, static=False, loader=None, **kwargs):
     """
     Serves the provided model as an LMTP/LMQL inference endpoint.
 
@@ -17,6 +17,7 @@ def serve(model_name, host="localhost", port=8080, cuda=False, dtype=None, stati
         cuda (bool, optional): If set, the model will be loaded on the GPU. Defaults to False.
         dtype (str, optional): What format to load the model weights. Options: 'float16' (not available on all models), '8bit' (requires bitsandbytes). Defaults to None.
         static (bool, optional): If set, the model cannot be switched on client request but remains fixed to the model specified in the model argument. Defaults to False.
+        loader (str, optional): If set, the model will be loaded using a library other than transformers. This is useful when loading quantized models in formats that are not yet supported by Transformers (like GTPQ). Defaults to None.
         **kwargs: Any other argument will be passed as a keyword argument to the AutoModelForCausalLM.from_pretrained function.
 
     """
@@ -27,6 +28,7 @@ def serve(model_name, host="localhost", port=8080, cuda=False, dtype=None, stati
         "cuda": cuda,
         "dtype": dtype,
         "static": static,
+        "loader": loader,
         **kwargs
     })
 
@@ -95,6 +97,10 @@ options:
   --static      If set, the model cannot be switched on client request but remains fixed to the model specified in the model argument.
   --dtype DTYPE  What format to load the model weights. Options: 'float16'
                  (not available on all models), '8bit' (requires bitsandbytes)
+  --loader OPT  If set, the model will be loaded using the corresponding option. Useful for loading quantized modules in formats not
+                supported by the transformers library, like GPTQ. Available options:
+                * auto-gptq (loads GPTQ based quantized models with auto-gptq. Consider adding `--use_safetensors true` if the model is
+                             distributed in the safetensor format)
   --[*] VALUE   Any other argument will be passed as a keyword argument to the AutoModelForCausalLM.from_pretrained function.
     """
 


### PR DESCRIPTION
This PR addresses the need to use GPTQ-quantized models, which can't currently be loaded with the transformers library.

It introduces an optional `--loader` flag with support for the `auto-gptq` option. When this option is specified, the (quantized) model will be loaded using the `auto_gptq` library.

To serve the model, run the following command:
```
lmql serve-model TheBloke/WizardCoder-15B-1.0-GPTQ --cuda --loader auto-gptq --use_safetensors true
```

or use the in-process invocation with:
```
from lmql.model("local:TheBloke/WizardCoder-15B-1.0-GPTQ", cuda=True, loader="auto-gptq", use_safetensors=True)
```