### PR TITLE
Fix "llama.cpp:" identifier stripping.

### DIFF
--- a/src/lmql/models/lmtp/backends/llama_cpp_model.py
+++ b/src/lmql/models/lmtp/backends/llama_cpp_model.py
@@ -18,7 +18,7 @@ class LlamaCppModel(LMTPModel):
         print("[Loading llama.cpp model from", self.model_identifier, "]", flush=True)
         if not "verbose" in kwargs.keys():
             kwargs["verbose"] = False
-        self.llm = Llama(model_path=model_identifier.strip("llama.cpp:"), **kwargs)
+        self.llm = Llama(model_path=model_identifier[len("llama.cpp:"):], **kwargs)
 
     def eos_token_id(self):
         return 2


### PR DESCRIPTION
Corrects the issue described in #124

The Python method `.strip( ` gives a _set_ of characters that Python will attempt to remove. So the call `.strip("llama.cpp:")` is equivalent to the call `.strip("aclmp:")`, and will strip any of that set of characters until it encounters one not in that set.

For me, this caused the identifier "llama.cpp:model-files/..." to come out as "odel-files/..." which was not the desired path.