### PR TITLE
Change LMTP scheduler polling to get with timeout

### DIFF
--- a/src/lmql/models/lmtp/lmtp_scheduler.py
+++ b/src/lmql/models/lmtp/lmtp_scheduler.py
@@ -190,7 +190,7 @@ class Scheduler:
         # get as many calls from the queue as possible within 0.1 seconds
         while time.time() - start < 0.1:
             try:
-                calls.append(self.queue.get_nowait())
+                calls.append(self.queue.get(block=True, timeout=time.time()-start+0.1))
             except QueueEmpty:
                 break
         # group calls into batches


### PR DESCRIPTION
Solves #125 

I did a tiny bit of math to get exactly how long of the 0.1 seconds remained after each wake-up, then setting the timeout for that long. This keeps nearly identical behavior (perhaps slightly lower throughput under absolute max load) but eliminates virtually all idle CPU usage.

Before:
![image](https://github.com/eth-sri/lmql/assets/11580688/fafb48e0-455f-46a9-bf4b-1edf7d64a074)

After:
![image](https://github.com/eth-sri/lmql/assets/11580688/181d3d84-4630-45ac-ad3c-9bb2769d414f)

