### PR TITLE
Fix lmtp_scheduler batching to take no more than 0.1 seconds

### DIFF
--- a/src/lmql/models/lmtp/lmtp_scheduler.py
+++ b/src/lmql/models/lmtp/lmtp_scheduler.py
@@ -188,11 +188,13 @@ class Scheduler:
         start = time.time()
         calls = []
         # get as many calls from the queue as possible within 0.1 seconds
+        first = True
         while time.time() - start < 0.1:
             try:
-                calls.append(self.queue.get(block=True, timeout=start+0.1-time.time()))
+                calls.append(self.queue.get(block=first, timeout=0.1))
+                first = False
             except QueueEmpty:
-                continue
+                break
         # group calls into batches
         batches_by_mode = {}
         for c in calls:

--- a/src/lmql/models/lmtp/lmtp_scheduler.py
+++ b/src/lmql/models/lmtp/lmtp_scheduler.py
@@ -190,9 +190,9 @@ class Scheduler:
         # get as many calls from the queue as possible within 0.1 seconds
         while time.time() - start < 0.1:
             try:
-                calls.append(self.queue.get(block=True, timeout=time.time()-start+0.1))
+                calls.append(self.queue.get(block=True, timeout=start+0.1-time.time()))
             except QueueEmpty:
-                break
+                continue
         # group calls into batches
         batches_by_mode = {}
         for c in calls:


### PR DESCRIPTION
Corrects mistake noted in a comment in #127 and also allows checking for the full 0.1 seconds even when the queue comes back as empty.

Related to (and solves) #125 