### PR TITLE
Fixed broken lmql command when using zsh-autoswitch-virtualenv plugin.

### DIFF
--- a/scripts/activate-dev.sh
+++ b/scripts/activate-dev.sh
@@ -1,5 +1,7 @@
 # use this script to run 'lmql' commands in the local development copy of LMQL
-ABSOLUTE_LMQL_PATH=$(cd $(dirname $0)/.. && pwd)
+cd $(dirname $0)/.. > /dev/null
+ABSOLUTE_LMQL_PATH=$(pwd)
+cd - > /dev/null
 echo "Using LMQL distribution in $ABSOLUTE_LMQL_PATH"
 export PYTHONPATH=$ABSOLUTE_LMQL_PATH/src
 alias lmql="PYTHONPATH=$ABSOLUTE_LMQL_PATH/src python -m lmql.cli \$*"


### PR DESCRIPTION
When changing directory into a python environment with the zsh-autoswitch-virtualenv plugin enabled, it prompts:
`Python virtualenv project detected. Run mkvenv to setup autoswitching`.

This output was part of the lmql command path that is set in `scripts/activate-dev.sh`.

By separating the `cd` command, this is fixed and the path is set correctly.
