### PR TITLE
Add Langchain LLM object based on calling LMQL query.

### DIFF
--- a/docs/source/python/langchain.ipynb
+++ b/docs/source/python/langchain.ipynb
@@ -163,13 +163,25 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In addition to using langchain utilities in LMQL query code, LMQL queries can also seamlessly be integrated as a `langchain` `Chain` component, or if necessary used as an LMTP client in place of a `langchain` `LLM`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Using LMQL as a Chain component"
+   ]
+  },
+  {
    "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In addition to using langchain utilities in LMQL query code, LMQL queries can also seamlessly be integrated as a `langchain` `Chain` component. \n",
-    "\n",
-    "For this consider, the sequential prompting example from the `langchain` documentation, where we first prompt the language model to propose a company name for a given product, and then ask it for a catchphrase.\n",
+    "Where possible, the preferred usage is as a `langchain` `Chain` component. For this, consider the sequential prompting example from the `langchain` documentation, where we first prompt the language model to propose a company name for a given product, and then ask it for a catchphrase.\n",
     "\n",
     "To get started, we first import the relevant langchain components, as well as LMQL."
    ]
@@ -355,6 +367,91 @@
    "metadata": {},
    "source": [
     "> Note that the full chain currently only works when run outside a Jupyter environment (in a script), due to the way langchain and LMQL rely on async vs. sequential calls. With further improvements to the `langchain` async API, this limitation can be expected to be removed."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Using LMQL as an LMTP client"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Using LMQL as an intermediate `langchain` `LLM` has been implemented as an temporary stage in bringing LMTP proper to `langchain`. Currently, this usage supports:\n",
+    "+ sync and async `LLM` calls\n",
+    "+ deterministic or temperature-based sampling\n",
+    "+ completion token count limits\n",
+    "+ stop word lists (accelerated by `LMQL`'s `STOPS_BEFORE()` constraint.)\n",
+    "+ Langchain callbacks (modeled off the langchain support for `ctransformers`, so limited to the extent of `ctransformers` support.)\n",
+    "\n",
+    "To get started, we import the LMQL langchain support."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from lmql.runtime.langchain.llm import LMQL as LMQL_LLM"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we can instantiate an LMQL `LLM` instance, which is a drop in for `langchain` `LLM` instances for most cases."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lmql_llm = LMQL_LLM(\n",
+    "    model=\"openai/chatgpt\",\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally, use the instance with any `langchain` systems desired."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "await lmql_llm.agenerate(\n",
+    "    \"## Intro: The\",\n",
+    "    stop=[\"\\n\", \".\"],\n",
+    "    temperature=0.9,\n",
+    "    max_length = 20,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "```\n",
+    " problem of identifying a subset of features in a data set that contribute significantly to the overall predictive\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `temperature` and `max_length` keywords may also be set during the `LLM` instantiation. Call-site keywords take precedence. If `temperature` is not given, the query will use `argmax` sampling. If `max_length` is not given, the generated result will not be truncated. (Beware running over the context length set on the LLM you're using as your LMQL model, as this frequently causes unrecoverable errors that may lock up the program.) `max_length` is counted as number of _newly generated_ tokens, not as total number of tokens."
    ]
   }
  ],

--- a/docs/source/python/lc2.py
+++ b/docs/source/python/lc2.py
@@ -1,0 +1,12 @@
+from lmql.runtime.langchain.llm import LMQL as LMQL_LLM
+
+lmql_llm = LMQL_LLM(
+    model="llama.cpp:airoboros-7b-gpt4-1.4.ggmlv3.q4_K_S.bin",
+)
+
+print(lmql_llm(
+    "## Intro: The",
+    stop=["\n", "."],
+    temperature=0.9,
+    max_length = 20,
+))

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,7 @@ install_requires =
 
 [options.extras_require]
     hf = transformers >=4.28.1; accelerate
+    langchain = langchain >=0.0.247
 
 [options.packages.find]
 where = src

--- a/src/lmql/runtime/langchain/__init__.py
+++ b/src/lmql/runtime/langchain/__init__.py
@@ -2,7 +2,7 @@ from typing import List, Dict, Any
 
 global lmql_chain_loop
 lmql_chain_loop = None
-from .loop import call_sync
+from ..loop import call_sync
 
 def chain(lmql_query_function, output_keys=None):
     from langchain.chains.base import Chain

--- a/src/lmql/runtime/langchain/llm.py
+++ b/src/lmql/runtime/langchain/llm.py
@@ -1,0 +1,246 @@
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Union
+
+import functools
+
+from langchain.llms.base import LLM
+
+import lmql
+from lmql.runtime.output_writer import BaseOutputWriter
+
+if TYPE_CHECKING:
+    from lmql.models.model import LMQLModel
+    from langchain.callbacks.manager import (
+        AsyncCallbackManagerForLLMRun,
+        CallbackManagerForLLMRun,
+    )
+
+DEFAULT_ENDPOINT = "localhost:8080"
+
+
+class _TextChunkCallbackWriter(BaseOutputWriter):
+    """Writes new tokens to a given callback."""
+
+    __slots__ = ("callback", "last_length")
+
+    def __init__(
+        self,
+        callback: Callable[[str], Any],
+        initial_length: int = 0,
+    ) -> None:
+        """Initialize the callback writer."""
+        super().__init__(allows_input=False)
+        self.callback = callback
+        self.last_length = initial_length
+
+    async def add_interpreter_head_state(
+        self,
+        variable,
+        head,
+        prompt: str,
+        where,
+        trace,
+        is_valid,
+        is_final,
+        mask,
+        num_tokens,
+        program_variables,
+    ) -> None:
+        last_length = self.last_length
+        self.last_length = len(prompt)
+        self.callback(prompt[last_length:])
+
+
+class LMQL(LLM):
+    """LMQL LLM models.
+
+    This piggybacks on LMQL to use any server compatible with
+     the LMTP protocol, so you should have the ``lmql``
+     python package installed.
+
+    Example:
+        .. code-block:: python
+
+            from langchain_lmtp import LMTP
+
+            llm = LMTP(model_id="lmtp://localhost:8000/1")
+    """
+
+    model: Union[str, "LMQLModel"]
+    """The model identifier to send to the LMTP server."""
+
+    endpoint: str = DEFAULT_ENDPOINT
+    """The endpoint to use for the LMTP server."""
+
+    max_length: Optional[int] = None
+    """Number of tokens to generate
+
+    minimum: 1
+    maximum: model-specific
+    """
+
+    temperature: Optional[float] = None
+    """Temperature to use for generation.
+
+    If None, uses argmax sampling.
+    minimum: 0.0
+    """
+
+    verbose: bool = False
+    """Whether to print prepared querystrings before use."""
+
+    @property
+    def _llm_type(self) -> str:
+        return "lmql_lmtp"
+
+    def _get_param(self, _key: str, _kwarg_dict: Dict[str, Any]) -> Any:
+        """Get a parameter for the LLM sampling process."""
+        return getattr(self, _key, None) or _kwarg_dict.get(_key)
+
+    def _prepare_querystring(
+        self,
+        stop: Optional[List[str]] = None,
+        **kwargs: Any,
+    ) -> str:
+        max_length = self._get_param("max_length", kwargs)
+
+        constraint_list = []
+        if max_length is not None and max_length > 0:
+            constraint_list.append(f"len(TOKENS(COMPLETION)) < {max_length+1}")
+        if stop is not None:
+            stop_constraints = " or ".join(
+                f"STOPS_BEFORE(COMPLETION, '{stopword}')" for stopword in stop
+            )
+            constraint_list.append(f"({stop_constraints})")
+        constraints = (
+            " and ".join(constraint_list) if constraint_list else None
+        )
+
+        temperature = self._get_param("temperature", kwargs)
+
+        if temperature is not None:
+            sampler_kwargs = {"temperature": temperature}
+            # Whoops! Turns out not a valid decoder arg
+            # top_k = self._get_param("top_k", kwargs)
+            # if top_k is not None and top_k > 0:
+            #     sampler_kwargs["top_k"] = top_k
+
+            if sampler_kwargs:
+                sampler_kwargs_formatted = ", ".join(
+                    (f"{key}={value}" for key, value in sampler_kwargs.items())
+                )
+                sampler_formatted = f"sample({sampler_kwargs_formatted})"
+        else:
+            sampler_formatted = "argmax"
+
+        result = f'{sampler_formatted}\n    "{{prompt}}[COMPLETION]"\n'
+
+        if constraints:
+            result += f"where\n    {repr(str(constraints))[1:-1]}"
+
+        if self.verbose:
+            print(f"LMQL LLM Query String:\n{result}")
+
+        return result
+
+    def _prepare_query(
+        self,
+        is_async: bool,
+        stop: Optional[List[str]] = None,
+        run_manager: Optional[
+            Union["AsyncCallbackManagerForLLMRun", "CallbackManagerForLLMRun"]
+        ] = None,
+        **kwargs: Any,
+    ) -> lmql.LMQLQueryFunction:
+        """Prepare a query function for the LLM sampling process."""
+        querystr: str = self._prepare_querystring(stop=stop, **kwargs)
+
+        output_writer = lmql.headless
+        if run_manager:
+            text_chunk_callback = functools.partial(
+                run_manager.on_llm_new_token, verbose=self.verbose
+            )
+            output_writer = _TextChunkCallbackWriter(
+                text_chunk_callback, initial_length=0
+            )
+
+        return lmql.query(
+            querystr,
+            is_async=is_async,
+            output_writer=output_writer,
+        )
+
+    def _call(
+        self,
+        prompt: str,
+        stop: Optional[List[str]] = None,
+        run_manager: Optional["CallbackManagerForLLMRun"] = None,
+        **kwargs,
+    ) -> str:
+        """Call out to LMQL
+
+        Args:
+            prompt: The prompt to pass into the model.
+            stop: A list of strings to stop generation when encountered.
+
+        Returns:
+            The string generated by the model.
+
+        Example:
+            .. code-block:: python
+                response = llm("Once upon a time, ")
+        """
+
+        model = (
+            lmql.model(self.model, endpoint=self.endpoint)
+            if isinstance(self.model, str)
+            else self.model
+        )
+
+        query = self._prepare_query(
+            is_async=False,
+            stop=stop,
+            run_manager=run_manager,
+            **kwargs,
+        )
+
+        result: List[lmql.LMQLResult] = query(model=model, prompt=prompt)
+
+        prompt_len: int = len(prompt)
+
+        return result[0].prompt[prompt_len:]
+
+    async def _acall(
+        self,
+        prompt: str,
+        stop: Optional[List[str]] = None,
+        run_manager: Optional["AsyncCallbackManagerForLLMRun"] = None,
+        **kwargs,
+    ) -> str:
+        """Asynchronous Call out to LMQL
+
+        Args:
+            prompt: The prompt to pass into the model.
+            stop: A list of strings to stop generation when encountered.
+
+        Returns:
+            The string generated by the model.
+        """
+
+        model = (
+            lmql.model(self.model, endpoint=self.endpoint)
+            if isinstance(self.model, str)
+            else self.model
+        )
+
+        query = self._prepare_query(
+            is_async=True,
+            stop=stop,
+            run_manager=run_manager,
+            **kwargs,
+        )
+
+        result: List[lmql.LMQLResult] = await query(model=model, prompt=prompt)
+
+        prompt_len: int = len(prompt)
+
+        return result[0].prompt[prompt_len:]


### PR DESCRIPTION
Hi all,

This adds the ability to use an LMQL.model (or any LMQL model identifier) as an inference engine for langchain. It's implemented pretty much the same way langchain implements `ctransformers`, using both the synchronous and asynchronous abstract methods of the `langchain` `LLM`, which is not the most fully-featured implementation (e.g. lacks caching) but provides for using Langchain's async support.

paryska99 was asking for something akin to this on the Discord and, while I wanted to do this directly on the LMTP level (and perhaps push it over there) I wound up having to commit most of my time to understand what langchain was asking for, and decided it was best placed as part of the langchain support built into LMQL.

I've also added early-draft documentation for the new component and a `langchain` extra in the project setup configuration.

Still want to do an LMTP-level version, but for now I hope something like this will help introduce more people to LMQL by letting them use its inference backends for their langchains.