### PR TITLE
playground: default to port used to load current page, not 3004

### DIFF
--- a/src/lmql/ui/playground/src/remote_process.js
+++ b/src/lmql/ui/playground/src/remote_process.js
@@ -2,9 +2,13 @@ import io from "socket.io-client"
 
 export class RemoteProcessConnection {
     constructor() {
-        const PORT = process.env.REACT_APP_SOCKET_PORT || 3004
+        const PORT = process.env.REACT_APP_SOCKET_PORT || null
 
-        this.socket = io.connect(':' + PORT);
+        if (PORT == null) {
+            this.socket = io.connect()
+        } else {
+            this.socket = io.connect(':' + PORT)
+        }
         this.socket.on('connect', () => {
             this.socket.on('app-result', data => {
                 this.onAppResult(data)


### PR DESCRIPTION
When started with `lmql playground`, `REACT_APP_SOCKET_PORT` is always set so this should be a noop.

(Refactoring out changes that aren't Nix-specific from #139).