### PR TITLE
Avoid abandoned/broken 4.0 release branch of aiohttp

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ package_dir =
 include_package_data = True
 python_requires = >=3.10
 install_requires =
+    aiohttp <4.0.0
     astunparse ==1.6.3
     openai
     termcolor


### PR DESCRIPTION
Without this, `python setup.py develop` could fail when trying to build an aiohttp release incompatible with Python 3.10 (see https://github.com/aio-libs/aiohttp/issues/6898 re the underlying issue).