### PR TITLE
live.js: When serving content from /nix/store, configure cache headers appropriately

### DIFF
--- a/src/lmql/ui/live/package.json
+++ b/src/lmql/ui/live/package.json
@@ -8,6 +8,7 @@
     "cors": "^2.8.5",
     "express": "^4.18.1",
     "monaco-editor": "^0.33.0",
+    "on-headers": "~1.0.2",
     "socket.io": "^4.5.1",
     "ws": "^8.10.0",
     "yarn": "^1.22.19"

--- a/src/lmql/ui/live/yarn.lock
+++ b/src/lmql/ui/live/yarn.lock
@@ -532,6 +532,11 @@ on-finished@2.4.1:
   dependencies:
     ee-first "1.1.1"
 
+on-headers@~1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/on-headers/-/on-headers-1.0.2.tgz#772b0ae6aaa525c399e489adfad90c403eb3c28f"
+  integrity sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==
+
 parseurl@~1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.3.tgz#9da19e7bee8d12dff0513ed5b76957793bc2e8d4"


### PR DESCRIPTION
Nix sets all mtimes to one second past epoch to make builds more reproducible. Consequently, `Last-Modified` times are not useful under `/nix/store`; however, because store paths include a hash (and thus are different between builds of non-identical source trees), _a hash of any given store path_ itself suffices as a unique identifier.