### PR TITLE
Respect "output_writer" parameter of run_file func

### DIFF
--- a/src/lmql/__init__.py
+++ b/src/lmql/__init__.py
@@ -61,7 +61,7 @@ async def run_file(filepath, *args, output_writer=None, force_model=None, **kwar
     with open(filepath, "r") as f:
         code = f.read()
     
-    q = _query_from_string(code, output_writer=printing)
+    q = _query_from_string(code, output_writer=output_writer)
     return await q(*args, **kwargs)
 
 async def run(code, *args, **kwargs):


### PR DESCRIPTION
It's a simple fix, as at the moment the `run_file` function does not respect `output_writer` kwarg.

I've grep'd the code and didn't any code in lmql that would break, but as far as API is concerned this is a "breaking" (?) change because the default output writer used downstream is "silent".