### PR TITLE
Refactor openai secret loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Alternatively, `lmql run` can be used to execute local `.lmql` files. Note that 
 
 ### Configuring OpenAI API Credentials
 
-If you want to use OpenAI models, you have to configure your API credentials. To do so, create a file `api.env` in the active working directory, with the following contents.
+If you want to use OpenAI models, you have to configure your API credentials. To do so you can either define the `OPENAI_API_KEY` environment variable or create a file `api.env` in the active working directory, with the following contents:
 
 ```
 openai-org: <org identifier>
@@ -108,6 +108,8 @@ openai-secret: <api secret>
 ```
 
 For system-wide configuration, you can also create an `api.env` file at `$HOME/.lmql/api.env` or at the project root of your LMQL distribution (e.g. `src/` in a development copy).
+
+Alternatively, you can use LMQL-specific env variables `LMQL_OPENAI_SECRET` and `LMQL_OPENAI_ORG`.
 
 ## Installing the Latest Development Version
 

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -40,7 +40,7 @@ Note that when using local [🤗 Transformers](https://huggingface.co/transforme
 
 ## Configuring OpenAI API Credentials
 
-If you want to use OpenAI models, you have to configure your API credentials. To do so you can either define the `OPENAI_API_KEY` environment variable or create a file `api.env` in the active working directory, with the following contents.
+If you want to use OpenAI models, you have to configure your API credentials. To do so you can either define the `OPENAI_API_KEY` environment variable or create a file `api.env` in the active working directory, with the following contents:
 
 ```
 openai-org: <org identifier>
@@ -48,3 +48,5 @@ openai-secret: <api secret>
 ```
 
 For system-wide configuration, you can also create an `api.env` file at `$HOME/.lmql/api.env` or at the project root of your LMQL distribution (e.g. `src/` in a development copy).
+
+Alternatively, you can use LMQL-specific env variables `LMQL_OPENAI_SECRET` and `LMQL_OPENAI_ORG`.

--- a/docs/source/language/openai.md
+++ b/docs/source/language/openai.md
@@ -17,7 +17,7 @@ Additionally, LMQL supports Azure OpenAI models. To learn more, please refer to 
 
 ### Configuring OpenAI API Credentials
 
-If you want to use OpenAI models, you have to configure your API credentials. To do so you can either define the `OPENAI_API_KEY` environment variable or create a file `api.env` in the active working directory, with the following contents.
+If you want to use OpenAI models, you have to configure your API credentials. To do so you can either define the `OPENAI_API_KEY` environment variable or create a file `api.env` in the active working directory, with the following contents:
 
 ```
 openai-org: <org identifier>
@@ -25,6 +25,8 @@ openai-secret: <api secret>
 ```
 
 For system-wide configuration, you can also create an `api.env` file at `$HOME/.lmql/api.env` or at the project root of your LMQL distribution (e.g. `src/` in a development copy).
+
+Alternatively, you can use LMQL-specific env variables `LMQL_OPENAI_SECRET` and `LMQL_OPENAI_ORG`.
 
 ### Monitoring OpenAI API use
 

--- a/src/lmql/runtime/bopenai/openai_api.py
+++ b/src/lmql/runtime/bopenai/openai_api.py
@@ -158,14 +158,17 @@ def get_endpoint_and_headers(kwargs):
     
     # use standard public API config
     from lmql.runtime.openai_secret import openai_secret, openai_org
+    headers = {
+        "Authorization": f"Bearer {openai_secret}",
+        "Content-Type": "application/json",
+    }
+    if openai_org:
+        headers['OpenAI-Organization'] = openai_org
     if kwargs["model"].startswith("gpt-3.5-turbo") or "gpt-4" in kwargs["model"]:
         endpoint = "https://api.openai.com/v1/chat/completions"
     else:
         endpoint = "https://api.openai.com/v1/completions"
-    return endpoint, {
-        "Authorization": f"Bearer {openai_secret}",
-        "Content-Type": "application/json",
-    }
+    return endpoint, headers
 
 async def chat_api(**kwargs):
     global stream_semaphore

--- a/src/lmql/runtime/openai_secret.py
+++ b/src/lmql/runtime/openai_secret.py
@@ -1,51 +1,87 @@
+from typing import Tuple
 import os
-
-openai_secret = None
-openai_org = None
 
 # get project root
 ROOT_DIR = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-def get_openai_secret():
-    if "LMQL_BROWSER" in os.environ:
-        # get openai secret from JS context
-        import js
-        openai_secret = str(js.get_openai_secret())
-        openai_org = str(js.get_openai_organization())
+_MISSING_CREDS_ERROR_MSG_TEMPLATE = """\
+To use openai/<models>, you have to configure your API credentials. To do so
+you can either define the `OPENAI_API_KEY` environment variable or create a
+file `api.env` in one of the following locations:
+
+{search_paths}
+
+To use OpenAI models you need to create an api.env file with the following
+contents:
         
-        return openai_secret, openai_org
-    elif "LMQL_OPENAI_SECRET" in os.environ and "LMQL_OPENAI_ORG" in os.environ:
-        return os.environ["LMQL_OPENAI_SECRET"], os.environ["LMQL_OPENAI_ORG"]
-    elif "OPENAI_API_KEY" in os.environ:
-        return os.environ["OPENAI_API_KEY"], ""
-    elif any(k.startswith("OPENAI_API_KEY") for k in os.environ):
-        return os.environ.get("OPENAI_API_KEY", None), ""
-    else:
-        search_paths = [
-            os.path.join(ROOT_DIR, "api.env"),
-            os.path.join(os.getcwd(), "api.env"),
-            os.path.join(os.getenv("HOME"), ".lmql", "api.env")
-        ]
-        
-        if not any(os.path.exists(p) for p in search_paths if p is not None):
-            m = """To use openai/<models> you have to set environment variable OPENAI_API_KEY or provide an api.env file in one of the following locations:\n\n{}\n\n To use OpenAI models you need to create an api.env file with the following contents:
         openai-secret: <your openai secret>
         openai-org: <your openai org>
         
-Alternatively, you may just define the environment variable OPENAI_API_KEY=sk-...
-        """.format("\n".join(" - " + p for p in search_paths if p is not None))
-            raise FileNotFoundError(m)
+For more info, check the related project docs:
+https://docs.lmql.ai/en/stable/language/openai.html#configuring-openai-api-credentials
+"""
 
-        valid_paths = [p for p in search_paths if os.path.exists(p)]
 
-        # get openai secret from file
-        with open(valid_paths[0], "r") as f:
-            for line in f:
-                if line.startswith("openai-secret: "):
-                    openai_secret = line.split("openai-secret: ")[1].strip()
-                elif line.startswith("openai-org: "):
-                    openai_org = line.split("openai-org: ")[1].strip()
-                    
-        return openai_secret, openai_org
-                
+def _get_secret_from_browser() -> Tuple[str, str]:
+    if "LMQL_BROWSER" not in os.environ:
+        raise ValueError("No LQM_BROWSER value in env variables")
+    # get openai secret from JS context
+    import js
+
+    openai_secret = str(js.get_openai_secret())
+    openai_org = str(js.get_openai_organization())
+    return openai_secret, openai_org
+
+
+def _get_secret_from_env() -> Tuple[str, str]:
+    openai_org = os.environ.get("LMQL_OPENAI_ORG", "")
+    if "LMQL_OPENAI_SECRET" in os.environ:
+        openai_secret = os.environ["LMQL_OPENAI_SECRET"]
+    elif "OPENAI_API_KEY" in os.environ:
+        openai_secret = os.environ["OPENAI_API_KEY"]
+    else:
+        raise ValueError("OpenAI API secret not found in env variables")
+    return openai_secret, openai_org
+
+
+def _get_secret_from_file() -> Tuple[str, str]:
+    search_paths = [
+        os.path.join(ROOT_DIR, "api.env"),
+        os.path.join(os.getcwd(), "api.env"),
+        os.path.join(os.getenv("HOME"), ".lmql", "api.env"),
+    ]
+
+    if not any(os.path.exists(p) for p in search_paths if p is not None):
+        m = _MISSING_CREDS_ERROR_MSG_TEMPLATE.format(
+            "\n".join(" - " + p for p in search_paths if p is not None)
+        )
+        raise FileNotFoundError(m)
+
+    valid_paths = [p for p in search_paths if os.path.exists(p)]
+
+    # get openai secret from file
+    with open(valid_paths[0], "r") as f:
+        for line in f:
+            if line.startswith("openai-secret: "):
+                openai_secret = line.split("openai-secret: ")[1].strip()
+            elif line.startswith("openai-org: "):
+                openai_org = line.split("openai-org: ")[1].strip()
+
+    return openai_secret, openai_org
+
+
+def get_openai_secret() -> Tuple[str, str]:
+    try:
+        return _get_secret_from_browser()
+    except ValueError:
+        pass
+
+    try:
+        return _get_secret_from_env()
+    except ValueError:
+        pass
+
+    return _get_secret_from_file()
+
+
 openai_secret, openai_org = get_openai_secret()

--- a/src/lmql/runtime/openai_secret.py
+++ b/src/lmql/runtime/openai_secret.py
@@ -53,7 +53,7 @@ def _get_secret_from_file() -> Tuple[str, str]:
 
     if not any(os.path.exists(p) for p in search_paths if p is not None):
         m = _MISSING_CREDS_ERROR_MSG_TEMPLATE.format(
-            "\n".join(" - " + p for p in search_paths if p is not None)
+            search_paths="\n".join(" - " + p for p in search_paths if p is not None)
         )
         raise FileNotFoundError(m)
 


### PR DESCRIPTION
I did a minor code refactoring for `openai_secret.py` module and updated related docs that i was able to find

**Motivation**
I've been looking for a way to set `openai_org` from env variable and did not find it in docs. Looking at the code, i found that this is already implemented by looking at `LMQL_OPENAI_ORG` parameter. While updating the docs, i've made some improvements (?) to the code that should make it easier to operate.

**Changes**
* Minor refactoring of the file (split a function into separate block for easier reading)
* `LMQL_OPENAI_ORG` can now be used with `OPENAI_API_KEY` (was previously only used with `LMQL_OPENAI_SECRET`)
* `LMQL_OPENAI_SECRET` can now be used without setting `LMQL_OPENAI_ORG`
* Removed a clause that was never working(?) (see comments)
* Error message now has a link to documentation

---
# Warning: Not tested!
I'm not yet familiar enough with this project to know which subset of tests to run in order to check this part of code, and i'm not yet invested enough to set up my machine to run all tests.

Can you guys please run tests against your machine before merging?