### PR TITLE
bugfix: relaunch OpenAI API if workers close

### DIFF
--- a/src/lmql/runtime/bopenai/__init__.py
+++ b/src/lmql/runtime/bopenai/__init__.py
@@ -92,6 +92,6 @@ class Completion:
     @staticmethod
     async def create(*args, **kwargs):
         global _api
-        if _api is None:
+        if _api is None or not _api.is_available():
             _api = AsyncOpenAIAPI()
         return await _api.complete(*args, **kwargs)


### PR DESCRIPTION
Fixes issue when running in async streamlit, where after completing an @query decorated function, async workers would close.

Without this setting, the following error is triggered:

```python
 if not self.is_available():
            raise APIShutDownException(f"bopenai requires at least one worker to be running to issue new complete requests.")
 ```  

Note that relaunching the API means that logging & cost-tracking are not always persisted.