### PR TITLE
adjustments to model naming arguments for adding quantization config

### DIFF
--- a/src/lmql/models/lmtp/utils.py
+++ b/src/lmql/models/lmtp/utils.py
@@ -1,21 +1,33 @@
+from transformers import BitsAndBytesConfig
 import warnings
+
 
 def rename_model_args(model_args):
     cuda = model_args.pop("cuda", False)
+    bits = model_args.pop("bits", 16)
     dtype = model_args.pop("dtype", None)
+    q_config = model_args.pop("quantization_config", None)
 
-    if dtype == "4bit":
+    if bits == 4:
         model_args["load_in_4bit"] = True
-    elif dtype == "8bit":
+    elif bits == 8:
         model_args["load_in_8bit"] = True
-    elif dtype is not None:
+
+    if dtype is not None:
         import torch
         model_args["torch_dtype"] = getattr(torch, dtype)
+
+    if type(q_config) is set:
+        q_config = {k: v for k, v in q_config.pop()}
+        model_args["quantization_config"] = BitsAndBytesConfig(**q_config)
+    elif q_config is not None:
+        warnings.warn(
+            "quantization_config is not a frozenset, so it will not be used. Use frozenset(Create BitsAndBytesConfig.__dict__.items()) instead.")
 
     # parse cuda
     if cuda:
         if "device_map" in model_args:
-            warnings.warn("Warning: device_map is set, but cuda is True. Ignoring 'cuda' which would set device_map to 'auto'.")
+            print("Warning: device_map is set, but cuda is True. Ignoring 'cuda' which would set device_map to 'auto'.")
         else:
             model_args["device_map"] = "auto"
 

--- a/src/lmql/models/lmtp/utils.py
+++ b/src/lmql/models/lmtp/utils.py
@@ -13,9 +13,13 @@ def rename_model_args(model_args):
     elif bits == 8:
         model_args["load_in_8bit"] = True
 
-    if dtype is not None:
+    if dtype is not None and (dtype != "4bit" or dtype != "8bit"):
         import torch
         model_args["torch_dtype"] = getattr(torch, dtype)
+    elif dtype == '4bit':
+        model_args["load_in_4bit"] = True
+    elif dtype == '8bit':
+        model_args["load_in_8bit"] = True
 
     if type(q_config) is set:
         q_config = {k: v for k, v in q_config.pop()}


### PR DESCRIPTION
I found the current input options specified for the invoking of local models to be very unsatisfactory. The specification of quantisation being exclusive with dtype specification is wrong since they are separate arguments and removes the ability to specify brain-float and 4bit quantisation which is the optimum strategy by the original qlora developers. In addition, simply adding 4bit quantisation is not enough, specifying a BitsAndBytesConfig object is necessary for double_quantisation features and more.

Current method is rather hacky with the passing of quantization parameters as a frozenset to get around objects/dictionaries not being hashable. Alternative approaches for the same outcome are welcome.