### PR TITLE
Fix broken "Get Started" link

### DIFF
--- a/docs/_components/LMHero.vue
+++ b/docs/_components/LMHero.vue
@@ -9,7 +9,7 @@
       <slot name="subtitle"></slot>
     </h2>
     <div class="buttons">
-    <a class="primary btn" href="/guide/">
+    <a class="primary btn" href="/docs/">
       Get Started
     </a>
     <a class="btn" href="https://github.com/eth-sri/lmql#contribute')">


### PR DESCRIPTION
/guide/ does not exist, it appears this has been relocated to top level /docs/.