### PR TITLE
Fixes doc urls

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ project.
 
 **Running Test Suites** The repository contains a number of test suites in the `src/lmql/tests/` directory. To run all 
 tests simply run `python src/lmql/tests/all.py`. Note that for some tests you need to configure an
-OpenAI API key according to the instructions in [documentation](https://docs.lmql.ai/en/stable/language/openai.html).
+OpenAI API key according to the instructions in [documentation](https://lmql.ai/docs/en/stable/language/openai.html).
 We are working to remove the external dependency on the OpenAI API, but for now it is still required
 for some tests. If you cannot get an API key, you can ask one of the core maintainers to run the
 tests for your, once your pull request is ready.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ project.
 
 **Running Test Suites** The repository contains a number of test suites in the `src/lmql/tests/` directory. To run all 
 tests simply run `python src/lmql/tests/all.py`. Note that for some tests you need to configure an
-OpenAI API key according to the instructions in [documentation](https://lmql.ai/docs/en/stable/language/openai.html).
+OpenAI API key according to the instructions in [documentation](https://lmql.ai/docs/models/openai.html).
 We are working to remove the external dependency on the OpenAI API, but for now it is still required
 for some tests. If you cannot get an API key, you can ask one of the core maintainers to run the
 tests for your, once your pull request is ready.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
   <p align="center">
     A programming language for large language models.
     <br />
-    <a href="https://docs.lmql.ai"><strong>Documentation »</strong></a>
+    <a href="https://lmql.ai/docs"><strong>Documentation »</strong></a>
     <br />
     <br />
     <a href="https://lmql.ai">Explore Examples</a>
@@ -52,25 +52,25 @@ Program Output:
 LMQL allows you to express programs that contain both, traditional algorithmic logic, and LLM calls. 
 At any point during execution, you can prompt an LLM on program variables in combination with standard natural language prompting, to leverage model reasoning capabilities in the context of your program.
 
-To better control LLM behavior, you can use the `where` keyword to specify constraints and data types of the generated text. This enables guidance of the model's reasoning process, and constraining of intermediate outputs using an [expressive constraint language](https://docs.lmql.ai/en/stable/language/constraints.html).
+To better control LLM behavior, you can use the `where` keyword to specify constraints and data types of the generated text. This enables guidance of the model's reasoning process, and constraining of intermediate outputs using an [expressive constraint language](https://lmql.ai/docs/en/stable/language/constraints.html).
 
-Beyond this linear form of scripting, LMQL also supports a number of decoding algorithms to execute your program, such as `argmax`, `sample` or even advanced branching decoders like [beam search and `best_k`](https://docs.lmql.ai/en/stable/language/decoders.html). 
+Beyond this linear form of scripting, LMQL also supports a number of decoding algorithms to execute your program, such as `argmax`, `sample` or even advanced branching decoders like [beam search and `best_k`](https://lmql.ai/docs/en/stable/language/decoders.html). 
 
-Learn more about LMQL by exploring thne **[Example Showcase](https://lmql.ai)**, by running your own programs in our **[browser-based Playground IDE](https://lmql.ai/playground)** or by reading the **[documentation](https://docs.lmql.ai)**.
+Learn more about LMQL by exploring thne **[Example Showcase](https://lmql.ai)**, by running your own programs in our **[browser-based Playground IDE](https://lmql.ai/playground)** or by reading the **[documentation](https://lmql.ai/docs)**.
 
 ## Feature Overview
 
 LMQL is designed to make working with language models like OpenAI and 🤗 Transformers more efficient and powerful through its advanced functionality, including multi-variable templates, conditional distributions, constraints, datatypes and control flow.
 
-- [X] **Python Syntax**: Write your queries using [familiar Python syntax](https://docs.lmql.ai/en/stable/language/overview.html), fully integrated with your Python environment (classes, variable captures, etc.)
-- [X] **Rich Control-Flow**: LMQL offers full Python support, enabling powerful [control flow and logic](https://docs.lmql.ai/en/stable/language/scripted_prompts.html) in your prompting logic.
-- [X] **Advanced Decoding**: Take advantage of advanced decoding techniques like [beam search, best_k, and more](https://docs.lmql.ai/en/stable/language/decoders.html).
-- [X] **Powerful Constraints Via Logit Masking**: Apply [constraints to model output](https://docs.lmql.ai/en/stable/language/constraints.html), e.g. to specify token length, character-level constraints, datatype and stopping phrases to get more control of model behavior.
+- [X] **Python Syntax**: Write your queries using [familiar Python syntax](https://lmql.ai/docs/en/stable/language/overview.html), fully integrated with your Python environment (classes, variable captures, etc.)
+- [X] **Rich Control-Flow**: LMQL offers full Python support, enabling powerful [control flow and logic](https://lmql.ai/docs/en/stable/language/scripted_prompts.html) in your prompting logic.
+- [X] **Advanced Decoding**: Take advantage of advanced decoding techniques like [beam search, best_k, and more](https://lmql.ai/docs/en/stable/language/decoders.html).
+- [X] **Powerful Constraints Via Logit Masking**: Apply [constraints to model output](https://lmql.ai/docs/en/stable/language/constraints.html), e.g. to specify token length, character-level constraints, datatype and stopping phrases to get more control of model behavior.
 - [X] **Optimizing Runtime:** LMQL leverages speculative execution to enable faster inference, constraint short-circuiting, more efficient token use and [tree-based caching](https://lmql.ai/blog/release-0.0.6.html).
-- [X] **Sync and Async API**: Execute hundreds of queries in parallel with LMQL's [asynchronous API](https://docs.lmql.ai/en/stable/python/python.html), which enables cross-query batching.
-- [X] **Multi-Model Support**: Seamlessly use LMQL with [OpenAI API, Azure OpenAI, and 🤗 Transformers models](https://docs.lmql.ai/en/stable/language/models.html).
+- [X] **Sync and Async API**: Execute hundreds of queries in parallel with LMQL's [asynchronous API](https://lmql.ai/docs/en/stable/python/python.html), which enables cross-query batching.
+- [X] **Multi-Model Support**: Seamlessly use LMQL with [OpenAI API, Azure OpenAI, and 🤗 Transformers models](https://lmql.ai/docs/en/stable/language/models.html).
 - [X] **Extensive Applications**: Use LMQL to implement advanced applications like [schema-safe JSON decoding](https://github.com/microsoft/guidance#guaranteeing-valid-syntax-json-example-notebook), [algorithmic prompting](https://twitter.com/lbeurerkellner/status/1648076868807950337), [interactive chat interfaces](https://twitter.com/lmqllang/status/1645776209702182917), and [inline tool use](https://lmql.ai/#kv).
-- [X] **Library Integration**: Easily employ LMQL in your existing stack leveraging [LangChain](https://docs.lmql.ai/en/stable/python/langchain.html) or [LlamaIndex](https://docs.lmql.ai/en/stable/python/llama_index.html).
+- [X] **Library Integration**: Easily employ LMQL in your existing stack leveraging [LangChain](https://lmql.ai/docs/en/stable/python/langchain.html) or [LlamaIndex](https://lmql.ai/docs/en/stable/python/llama_index.html).
 - [X] **Flexible Tooling**: Enjoy an interactive development experience with [LMQL's Interactive Playground IDE](https://lmql.ai/playground), and [Visual Studio Code Extension](https://marketplace.visualstudio.com/items?itemName=lmql-team.lmql).
 - [X] **Output Streaming**: Stream model output easily via [WebSocket, REST endpoint, or Server-Sent Event streaming](https://github.com/eth-sri/lmql/blob/main/src/lmql/output/).
 

--- a/README.md
+++ b/README.md
@@ -52,9 +52,9 @@ Program Output:
 LMQL allows you to express programs that contain both, traditional algorithmic logic, and LLM calls. 
 At any point during execution, you can prompt an LLM on program variables in combination with standard natural language prompting, to leverage model reasoning capabilities in the context of your program.
 
-To better control LLM behavior, you can use the `where` keyword to specify constraints and data types of the generated text. This enables guidance of the model's reasoning process, and constraining of intermediate outputs using an [expressive constraint language](https://lmql.ai/docs/en/stable/language/constraints.html).
+To better control LLM behavior, you can use the `where` keyword to specify constraints and data types of the generated text. This enables guidance of the model's reasoning process, and constraining of intermediate outputs using an [expressive constraint language](https://lmql.ai/docs/language/constraints.html).
 
-Beyond this linear form of scripting, LMQL also supports a number of decoding algorithms to execute your program, such as `argmax`, `sample` or even advanced branching decoders like [beam search and `best_k`](https://lmql.ai/docs/en/stable/language/decoders.html). 
+Beyond this linear form of scripting, LMQL also supports a number of decoding algorithms to execute your program, such as `argmax`, `sample` or even advanced branching decoders like [beam search and `best_k`](https://lmql.ai/docs/language/decoding.html). 
 
 Learn more about LMQL by exploring thne **[Example Showcase](https://lmql.ai)**, by running your own programs in our **[browser-based Playground IDE](https://lmql.ai/playground)** or by reading the **[documentation](https://lmql.ai/docs)**.
 
@@ -62,15 +62,15 @@ Learn more about LMQL by exploring thne **[Example Showcase](https://lmql.ai)**,
 
 LMQL is designed to make working with language models like OpenAI and 🤗 Transformers more efficient and powerful through its advanced functionality, including multi-variable templates, conditional distributions, constraints, datatypes and control flow.
 
-- [X] **Python Syntax**: Write your queries using [familiar Python syntax](https://lmql.ai/docs/en/stable/language/overview.html), fully integrated with your Python environment (classes, variable captures, etc.)
-- [X] **Rich Control-Flow**: LMQL offers full Python support, enabling powerful [control flow and logic](https://lmql.ai/docs/en/stable/language/scripted_prompts.html) in your prompting logic.
-- [X] **Advanced Decoding**: Take advantage of advanced decoding techniques like [beam search, best_k, and more](https://lmql.ai/docs/en/stable/language/decoders.html).
-- [X] **Powerful Constraints Via Logit Masking**: Apply [constraints to model output](https://lmql.ai/docs/en/stable/language/constraints.html), e.g. to specify token length, character-level constraints, datatype and stopping phrases to get more control of model behavior.
+- [X] **Python Syntax**: Write your queries using [familiar Python syntax](https://lmql.ai/docs/language/overview.html), fully integrated with your Python environment (classes, variable captures, etc.)
+- [X] **Rich Control-Flow**: LMQL offers full Python support, enabling powerful [control flow and logic](https://lmql.ai/docs/language/scripted-prompting.html) in your prompting logic.
+- [X] **Advanced Decoding**: Take advantage of advanced decoding techniques like [beam search, best_k, and more](https://lmql.ai/docs/language/decoding.html).
+- [X] **Powerful Constraints Via Logit Masking**: Apply [constraints to model output](https://lmql.ai/docs/language/constraints.html), e.g. to specify token length, character-level constraints, datatype and stopping phrases to get more control of model behavior.
 - [X] **Optimizing Runtime:** LMQL leverages speculative execution to enable faster inference, constraint short-circuiting, more efficient token use and [tree-based caching](https://lmql.ai/blog/release-0.0.6.html).
-- [X] **Sync and Async API**: Execute hundreds of queries in parallel with LMQL's [asynchronous API](https://lmql.ai/docs/en/stable/python/python.html), which enables cross-query batching.
-- [X] **Multi-Model Support**: Seamlessly use LMQL with [OpenAI API, Azure OpenAI, and 🤗 Transformers models](https://lmql.ai/docs/en/stable/language/models.html).
+- [X] **Sync and Async API**: Execute hundreds of queries in parallel with LMQL's [asynchronous API](https://lmql.ai/docs/lib/python.html), which enables cross-query batching.
+- [X] **Multi-Model Support**: Seamlessly use LMQL with [OpenAI API, Azure OpenAI, and 🤗 Transformers models](https://lmql.ai/docs/models/).
 - [X] **Extensive Applications**: Use LMQL to implement advanced applications like [schema-safe JSON decoding](https://github.com/microsoft/guidance#guaranteeing-valid-syntax-json-example-notebook), [algorithmic prompting](https://twitter.com/lbeurerkellner/status/1648076868807950337), [interactive chat interfaces](https://twitter.com/lmqllang/status/1645776209702182917), and [inline tool use](https://lmql.ai/#kv).
-- [X] **Library Integration**: Easily employ LMQL in your existing stack leveraging [LangChain](https://lmql.ai/docs/en/stable/python/langchain.html) or [LlamaIndex](https://lmql.ai/docs/en/stable/python/llama_index.html).
+- [X] **Library Integration**: Easily employ LMQL in your existing stack leveraging [LangChain](https://lmql.ai/docs/lib/integrations/langchain.html) or [LlamaIndex](https://lmql.ai/docs/lib/integrations/llama_index.html).
 - [X] **Flexible Tooling**: Enjoy an interactive development experience with [LMQL's Interactive Playground IDE](https://lmql.ai/playground), and [Visual Studio Code Extension](https://marketplace.visualstudio.com/items?itemName=lmql-team.lmql).
 - [X] **Output Streaming**: Stream model output easily via [WebSocket, REST endpoint, or Server-Sent Event streaming](https://github.com/eth-sri/lmql/blob/main/src/lmql/output/).
 

--- a/docs/.vitepress/link-checker.js
+++ b/docs/.vitepress/link-checker.js
@@ -77,8 +77,8 @@ markdownFiles.forEach(file => {
                     // ignore internal links
                     return
                 }
-                if (url.startsWith("https://docs.lmql.ai")) {
-                    console.log(`File ${file}:${lineno} contains direct link to docs.lmql.ai: ${url}`)
+                if (url.startsWith("https://lmql.ai/docs")) {
+                    console.log(`File ${file}:${lineno} contains direct link to lmql.ai/docs: ${url}`)
                     return
                 }
 

--- a/docs/blog/posts/release-0.0.6.4.md
+++ b/docs/blog/posts/release-0.0.6.4.md
@@ -16,7 +16,7 @@ Among many things, this update contains several bug fixes and improvements. The 
    To learn more about the internals of the new streaming protocol, i.e. the language model transport protocol (LMTP), you can find more details in [this README file](https://github.com/eth-sri/lmql/blob/main/src/lmql/models/lmtp/README.md). In the future, we intend to implement more model backends using LMTP, streamlining communication between LMQL and models.
 
    <div style="text-align:center">
-    <img src="https://docs.lmql.ai/en/stable/_images/inference.svg" width="80%" />
+    <img src="https://lmql.ai/docs/en/stable/_images/inference.svg" width="80%" />
     <br>
     <i>LMQL's new streaming protocol (LMTP) allows for faster local model inference.</i>
    </div>

--- a/docs/blog/posts/release-0.0.6.4.md
+++ b/docs/blog/posts/release-0.0.6.4.md
@@ -16,7 +16,7 @@ Among many things, this update contains several bug fixes and improvements. The 
    To learn more about the internals of the new streaming protocol, i.e. the language model transport protocol (LMTP), you can find more details in [this README file](https://github.com/eth-sri/lmql/blob/main/src/lmql/models/lmtp/README.md). In the future, we intend to implement more model backends using LMTP, streamlining communication between LMQL and models.
 
    <div style="text-align:center">
-    <img src="https://lmql.ai/docs/en/stable/_images/inference.svg" width="80%" />
+    <img src="https://lmql.ai/assets/inference.f47a6f3e.svg" width="80%" />
     <br>
     <i>LMQL's new streaming protocol (LMTP) allows for faster local model inference.</i>
    </div>

--- a/scripts/flake.d/pyproject.toml
+++ b/scripts/flake.d/pyproject.toml
@@ -8,7 +8,7 @@ authors = [
   "Martin Vechev",
 ]
 homepage = "https://lmql.ai"
-documentation = "https://docs.lmql.ai"
+documentation = "https://lmql.ai/docs"
 maintainers = ["The LMQL Team <hello@lmql.ai>"]
 license = "Apache-2.0"
 readme = "README.md"

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ long_description = file: README.md
 long_description_content_type = text/markdown
 url = https://lmql.ai
 project_urls =
-    Docs = https://docs.lmql.ai
+    Docs = https://lmql.ai/docs
 classifiers =
     Programming Language :: Python :: 3
     Operating System :: OS Independent

--- a/src/lmql/models/lmtp/README.md
+++ b/src/lmql/models/lmtp/README.md
@@ -6,7 +6,7 @@ It relies on the idea of separating model loading and inference into a separate 
 
 ![Architecture](../../../../docs/source/images/inference.svg)
 
-Read more about using LMTP in LMQL, in the [LMQL documentation](https://docs.lmql.ai/en/latest/language/hf.html).
+Read more about using LMTP in LMQL, in the [LMQL documentation](https://lmql.ai/docs/en/latest/language/hf.html).
 
 ## Communication Channels
 

--- a/src/lmql/models/lmtp/README.md
+++ b/src/lmql/models/lmtp/README.md
@@ -6,7 +6,7 @@ It relies on the idea of separating model loading and inference into a separate 
 
 ![Architecture](../../../../docs/source/images/inference.svg)
 
-Read more about using LMTP in LMQL, in the [LMQL documentation](https://lmql.ai/docs/en/latest/language/hf.html).
+Read more about using LMTP in LMQL, in the [LMQL documentation](https://lmql.ai/docs/models/hf.html).
 
 ## Communication Channels
 

--- a/src/lmql/runtime/openai_secret.py
+++ b/src/lmql/runtime/openai_secret.py
@@ -18,7 +18,7 @@ contents:
         openai-org: <your openai org>
         
 For more info, check the related project docs:
-https://docs.lmql.ai/en/stable/language/openai.html#configuring-openai-api-credentials
+https://lmql.ai/docs/en/stable/language/openai.html#configuring-openai-api-credentials
 """
 
 

--- a/src/lmql/runtime/openai_secret.py
+++ b/src/lmql/runtime/openai_secret.py
@@ -18,7 +18,7 @@ contents:
         openai-org: <your openai org>
         
 For more info, check the related project docs:
-https://lmql.ai/docs/en/stable/language/openai.html#configuring-openai-api-credentials
+https://lmql.ai/docs/models/openai.html#configuring-openai-api-credentials
 """
 
 

--- a/src/lmql/ui/playground/src/App.jsx
+++ b/src/lmql/ui/playground/src/App.jsx
@@ -616,7 +616,7 @@ function ModelSelection(props) {
       <span className="instructions">
         <b>Custom Model</b><br/>
         Specify the model to execute your query with. You can also type in the text field above. <i>This setting will override any model specified by the query.</i>
-        {configuration.BROWSER_MODE ? <><br/><a href={"https://lmql.ai/docs/en/latest/quickstart.html"} target="_blank" rel="noreferrer" className="hidden-on-small">
+        {configuration.BROWSER_MODE ? <><br/><a href={"https://lmql.ai/docs/"} target="_blank" rel="noreferrer" className="hidden-on-small">
           Install LMQL locally </a> to use other models, e.g. from 🤗 Tranformers</>
         : null}
       </span>
@@ -2864,7 +2864,7 @@ class App extends React.Component {
             {!configuration.NEXT_MODE && <>Explore LMQL</>}
             {configuration.NEXT_MODE && <>Explore New Features</>}
           </FancyButton>}
-          {window.location.hostname.includes("lmql.ai") && <a href={"https://lmql.ai/docs/en/latest/quickstart.html"} target="_blank" rel="noreferrer" className="hidden-on-small">
+          {window.location.hostname.includes("lmql.ai") && <a href={"https://lmql.ai/docs/"} target="_blank" rel="noreferrer" className="hidden-on-small">
           Install LMQL Locally </a>}
           <Spacer />
           {/* show tooltip with build time */}

--- a/src/lmql/ui/playground/src/App.jsx
+++ b/src/lmql/ui/playground/src/App.jsx
@@ -616,7 +616,7 @@ function ModelSelection(props) {
       <span className="instructions">
         <b>Custom Model</b><br/>
         Specify the model to execute your query with. You can also type in the text field above. <i>This setting will override any model specified by the query.</i>
-        {configuration.BROWSER_MODE ? <><br/><a href={"https://docs.lmql.ai/en/latest/quickstart.html"} target="_blank" rel="noreferrer" className="hidden-on-small">
+        {configuration.BROWSER_MODE ? <><br/><a href={"https://lmql.ai/docs/en/latest/quickstart.html"} target="_blank" rel="noreferrer" className="hidden-on-small">
           Install LMQL locally </a> to use other models, e.g. from 🤗 Tranformers</>
         : null}
       </span>
@@ -2864,7 +2864,7 @@ class App extends React.Component {
             {!configuration.NEXT_MODE && <>Explore LMQL</>}
             {configuration.NEXT_MODE && <>Explore New Features</>}
           </FancyButton>}
-          {window.location.hostname.includes("lmql.ai") && <a href={"https://docs.lmql.ai/en/latest/quickstart.html"} target="_blank" rel="noreferrer" className="hidden-on-small">
+          {window.location.hostname.includes("lmql.ai") && <a href={"https://lmql.ai/docs/en/latest/quickstart.html"} target="_blank" rel="noreferrer" className="hidden-on-small">
           Install LMQL Locally </a>}
           <Spacer />
           {/* show tooltip with build time */}
@@ -2892,7 +2892,7 @@ class App extends React.Component {
                 <a href="https://github.com/eth-sri/lmql" disabled target="_blank" rel="noreferrer"><BsGithub/>LMQL on Github</a>
               </li>
               <li>
-                <a href="https://docs.lmql.ai" disabled target="_blank" rel="noreferrer"><BsBook/>Documentation</a>
+                <a href="https://lmql.ai/docs" disabled target="_blank" rel="noreferrer"><BsBook/>Documentation</a>
               </li>
               <span>
                 LMQL {this.state.buildInfo.commit} 

--- a/src/lmql/ui/playground/src/Explore.jsx
+++ b/src/lmql/ui/playground/src/Explore.jsx
@@ -489,7 +489,7 @@ export function Explore() {
     let description = <>
     LMQL is a query language for large language models. Explore the examples below to get started.
     <LinkBox>
-      <a className="button" target="_blank" rel="noreferrer" href="https://docs.lmql.ai">Documentation</a>
+      <a className="button" target="_blank" rel="noreferrer" href="https://lmql.ai/docs">Documentation</a>
       <a className="button" target="_blank" rel="noreferrer" href="https://lmql.ai">Overview</a>
     </LinkBox>
     </>

--- a/src/lmql/ui/vscode/README.md
+++ b/src/lmql/ui/vscode/README.md
@@ -2,4 +2,4 @@
 
 This extension provides syntax highlighting for the [Language Model Query Language (LMQL)](https://lmql.ai) in Visual Studio Code.
 
-To learn more about LMQL, visit the [LMQL documentation](https://docs.lmql.ai) or the [LMQL GitHub repository](https://github.com/eth-sri/lmql).
+To learn more about LMQL, visit the [LMQL documentation](https://lmql.ai/docs) or the [LMQL GitHub repository](https://github.com/eth-sri/lmql).


### PR DESCRIPTION
replaces 'docs.lmql.ai' with 'lmql.ai/docs', updates all broken links to their current versions