### PR TITLE
Broad exception handling while checking tiktoken tokenizer

### DIFF
--- a/src/lmql/runtime/tokenizer.py
+++ b/src/lmql/runtime/tokenizer.py
@@ -311,6 +311,7 @@ def _load_tokenizer(model_identifier, type, **kwargs) -> LMQLTokenizer:
         try:
             if TiktokenTokenizer.is_available(tiktoken_identifier):
                 tiktoken_available = True
+        # FIXME broad exception handling hides environment issues when downloading data for tokenizer, e.g. due to HTTPS errors
         except:
             tiktoken_available = False
         


### PR DESCRIPTION
Would love to hear feedback about incorrect detection of `TiktokenTokenizer` availability due to environment problems, e.g. networking connectivity.

Should there be a distinction of the handled errors and runtime errors which stop further execution?