### PR TITLE
Added verbose in ops.follow to print

### DIFF
--- a/src/lmql/ops/ops.py
+++ b/src/lmql/ops/ops.py
@@ -744,6 +744,8 @@ class RegexOp(Node):
         x = args[0]
         ex = args[1]
         assert isinstance(ex, str)
+
+        verbose = kwargs.get("verbose", False)
         
         if x == strip_next_token(x):
             return fmap(
@@ -751,8 +753,8 @@ class RegexOp(Node):
             )
 
         r = Regex(ex)
-        rd = r.d(strip_next_token(x), verbose=False) # take derivative
-        print(f"r={r.pattern} x={strip_next_token(x)} --> {rd.pattern if rd is not None else '[no drivative]'}")
+        rd = r.d(strip_next_token(x), verbose=verbose) # take derivative
+        if verbose: print(f"r={r.pattern} x={strip_next_token(x)} --> {rd.pattern if rd is not None else '[no drivative]'}")
         if rd is None:
             return False 
         elif rd.is_empty(): # derivative is empty -> full match; therefore we must end


### PR DESCRIPTION
There is currently a rouge print that is not behind verbose in ops.py so that causing a lot printing to occur when using REGEX in LMQL. Added getting verbose from kwargs and printing only if its `True`