### PR TITLE
Fixed bug where ContextTracer wasn't properly initializing a tracer

### DIFF
--- a/src/lmql/runtime/tracing/tracer.py
+++ b/src/lmql/runtime/tracing/tracer.py
@@ -194,7 +194,7 @@ class ContextTracer:
         self.tracer = tracer
 
     def __enter__(self):
-        _ensure_tracer
+        _ensure_tracer()
         current = _tracer.get()[-1] if len(_tracer.get()) > 0 else None
         if current is not None:
             if self.tracer.parent is not None:


### PR DESCRIPTION
I'm not sure what the purpose of this function is, but it seems like it was not called properly.

Fixes the following error on Colab:

```python
import lmql
model = lmql.model("openai/gpt-3.5-turbo-instruct")

# LookupError: <ContextVar name='logger' at 0x7df755679530>
await model.score("Hello", ["World", "Apples", "Oranges"])
```

Feel free to close if not correct / doesn't actually fix anything. I did notice that the tracer seemed to be initialized here https://github.com/eth-sri/lmql/blob/ab02526ddf9883aff4acda4e76c5a2a1cc136bf1/src/lmql/runtime/tracing/tracer.py#L156 so I'm not 100% sure what `_ensure_tracer()` is supposed to do.