### PR TITLE
Fix broken links in docs

### DIFF
--- a/docs/docs/language/reference.md
+++ b/docs/docs/language/reference.md
@@ -44,9 +44,9 @@ For more information and example-based discussion on how to use LMQL, please ref
 
 The LMQL language comprises two syntax variants:
 
-* The modern, more minimalistic [standard syntax](#modern-syntax) that relies on a very small set of language constructs in an otherwise standard Python environment. This syntax is the main focus for the continued development of LMQL.
+* The modern, more minimalistic [standard syntax](#standard-syntax) that relies on a very small set of language constructs in an otherwise standard Python environment. This syntax is the main focus for the continued development of LMQL.
 
-* A *legacy* [standalone syntax](#legacy-syntax) that is more static in nature but relevant for standalone LMQL use-cases.
+* A *legacy* [standalone syntax](#standalone-syntax) that is more static in nature but relevant for standalone LMQL use-cases.
 
 Both syntax variants are compatible and can be used interchangeably. 
 

--- a/docs/docs/lib/generations.md
+++ b/docs/docs/lib/generations.md
@@ -36,7 +36,7 @@ The snippet above demonstrates the different components of the Generations API:
 
 - **`lmql.LLM`** At the core of the Generations API are `lmql.LLM` objects. Using the `lmql.model(...)` constructor, you can access a wide range of different models, as described in the [Models](../models/index.md) chapter. This includes support for models running in the same process, in a separate worker process or cloud-based models available via a API endpoint.
 
-- [**`lmql.LLM.generate(...)`**](#llmqgenerate) is a simple function to generating text completions based on a given prompt. This can be helpful to quickly obtain single-step completions, or to generate a list of completions for a given prompt.
+- [**`lmql.LLM.generate(...)`**](#lmqlgenerate) is a simple function to generating text completions based on a given prompt. This can be helpful to quickly obtain single-step completions, or to generate a list of completions for a given prompt.
 
 -   [**`lmql.LLM.score(...)`**](#lmqlscore) allows you to directly access the scores, your model assigns to the tokenized representation of your input prompt and continuations. This can be helpful for tasks such as classification or ranking. 
     

--- a/docs/docs/lib/generations.md
+++ b/docs/docs/lib/generations.md
@@ -36,9 +36,9 @@ The snippet above demonstrates the different components of the Generations API:
 
 - **`lmql.LLM`** At the core of the Generations API are `lmql.LLM` objects. Using the `lmql.model(...)` constructor, you can access a wide range of different models, as described in the [Models](../models/index.md) chapter. This includes support for models running in the same process, in a separate worker process or cloud-based models available via a API endpoint.
 
-- [**`lmql.LLM.generate(...)`**](#lmql-generate) is a simple function to generating text completions based on a given prompt. This can be helpful to quickly obtain single-step completions, or to generate a list of completions for a given prompt.
+- [**`lmql.LLM.generate(...)`**](#llmqgenerate) is a simple function to generating text completions based on a given prompt. This can be helpful to quickly obtain single-step completions, or to generate a list of completions for a given prompt.
 
--   [**`lmql.LLM.score(...)`**](#lmql-score) allows you to directly access the scores, your model assigns to the tokenized representation of your input prompt and continuations. This can be helpful for tasks such as classification or ranking. 
+-   [**`lmql.LLM.score(...)`**](#lmqlscore) allows you to directly access the scores, your model assigns to the tokenized representation of your input prompt and continuations. This can be helpful for tasks such as classification or ranking. 
     
     The result is an [`lmql.ScoringResult`](https://github.com/eth-sri/lmql/blob/main/src/lmql/api/scoring.py) object, which contains the scores for each continuation, as well as the prompt and continuations used for scoring. It provides a convenient interface for score aggregation, normalization and maximum selection.
 
@@ -49,7 +49,7 @@ The snippet above demonstrates the different components of the Generations API:
 
 ## `lmql.LLM` Objects
 
-At the core, `lmql.LLM` objects represent a specific language model and provide methods for generation and scoring. An `lmql.LLM` is instantiated using [`lmql.model(...)`](../models/index.md) and can be passed [as-is to LMQL query programs](../models/index.md#loading-models) or to the top-level [`lmql.generate`](#lmql-generate) and [`lmql.score`](#lmql-score) functions.
+At the core, `lmql.LLM` objects represent a specific language model and provide methods for generation and scoring. An `lmql.LLM` is instantiated using [`lmql.model(...)`](../models/index.md) and can be passed [as-is to LMQL query programs](../models/index.md#loading-models) or to the top-level [`lmql.generate`](#lmqlgenerate) and [`lmql.score`](#lmqlscore) functions.
 
 ### `LLM.generate(...)`
 
@@ -74,7 +74,7 @@ Generates a text completion based on a given prompt. Returns the full prompt + c
 
 **Return Value** The function returns a string or a list of strings, depending on the decoder in use (`decoder=argmax` yields a single sequence, `decoder="sample", n=2` yields two sequences, etc.).
 
-**Asynchronous** The function is asynchronous and should be used with [`asyncio`](https://docs.python.org/3/library/asyncio.html) and with `await`. When run in parallel, multiple generations will be batched and parallelized across multiple calls to the same model. For synchronous use, you can rely on [`LLM.generate_sync`](#llm-generate_sync), note however, that in this case, the function will block the current thread until generation is complete.
+**Asynchronous** The function is asynchronous and should be used with [`asyncio`](https://docs.python.org/3/library/asyncio.html) and with `await`. When run in parallel, multiple generations will be batched and parallelized across multiple calls to the same model. For synchronous use, you can rely on [`LLM.generate_sync`](#llmgenerate_sync), note however, that in this case, the function will block the current thread until generation is complete.
 
 ### `LLM.generate_sync(...)`
 
@@ -82,7 +82,7 @@ Generates a text completion based on a given prompt. Returns the full prompt + c
 def generate_sync(self, *args, **kwargs):
 ```
 
-Synchronous version of [`lmql.LLM.generate`](#llm-generate).
+Synchronous version of [`lmql.LLM.generate`](#llmgenerate).
 
 ### `LLM.score(...)`
 
@@ -105,7 +105,7 @@ For instance `await m.score("Hello", ["World", "Apples", "Oranges"])` would scor
 
 **Return Value** The result is an [`lmql.ScoringResult`](https://github.com/eth-sri/lmql/blob/main/src/lmql/api/scoring.py) object, which contains the scores for each continuation, as well as the prompt and continuations used for scoring. It provides a convenient interface for score aggregation, normalization and maximum selection.
 
-**Asynchronous** The function is asynchronous and should be used with [`asyncio`](https://docs.python.org/3/library/asyncio.html) and with `await`. When run in parallel, multiple generations will be batched and parallelized across multiple calls to the same model. For synchronous use, you can rely on [`LLM.score_sync`](#llm-score-sync).
+**Asynchronous** The function is asynchronous and should be used with [`asyncio`](https://docs.python.org/3/library/asyncio.html) and with `await`. When run in parallel, multiple generations will be batched and parallelized across multiple calls to the same model. For synchronous use, you can rely on [`LLM.score_sync`](#llmscore_sync).
 
 ### `LLM.score_sync(...)`
 
@@ -113,7 +113,7 @@ For instance `await m.score("Hello", ["World", "Apples", "Oranges"])` would scor
 def score_sync(self, *args, **kwargs)
 ```
 
-Synchronous version of [`lmql.LLM.score`](#llm-score).
+Synchronous version of [`lmql.LLM.score`](#llmscore).
 
 ## Top-Level Functions
 
@@ -131,14 +131,14 @@ async def lmql.generate(
 ) -> Union[str, List[str]]
 ```
 
-`lmql.generate` generates text completions based on a given prompt and behaves just like [`LLM.generate`](#llm-generate), 
+`lmql.generate` generates text completions based on a given prompt and behaves just like [`LLM.generate`](#llmgenerate), 
 with the provided `model` instance or model name.
 
-If no `model` is provided, the default model is used. See [`lmql.set_default_model`](#lmql-set_default_model) for more information.
+If no `model` is provided, the default model is used. See [`lmql.set_default_model`](#lmqlset_default_model) for more information.
 
 ### `lmql.generate_sync(...)`
 
-Synchronous version of [`lmql.generate`](#lmql-generate).
+Synchronous version of [`lmql.generate`](#lmqlgenerate).
 
 ### `lmql.score(...)`
 
@@ -151,14 +151,14 @@ async def score(
 ) -> lmql.ScoringResult
 ```
 
-`lmql.score` scores different continuation `values` for a given `prompt` and behaves just like [`LLM.score`](#llm-score),
+`lmql.score` scores different continuation `values` for a given `prompt` and behaves just like [`LLM.score`](#llmscore),
 with the provided `model` instance or model name.
 
-If no `model` is provided, the default model is used. See [`lmql.set_default_model`](#lmql-set_default_model) for more information.
+If no `model` is provided, the default model is used. See [`lmql.set_default_model`](#lmqlset_default_model) for more information.
 
 ### `lmql.score_sync(...)`
 
-Synchronous version of [`lmql.score`](#lmql-score).
+Synchronous version of [`lmql.score`](#lmqlscore).
 
 ### `lmql.set_default_model(...)`
 
@@ -166,6 +166,6 @@ Synchronous version of [`lmql.score`](#lmql-score).
 def set_default_model(model: Union[str, LLM])
 ```
 
-Sets the model to be used when no `from` clause or `@lmql.query(model=<model>)` are specified in LMQL. The default model applies globally in the current process and affects both LMQL queries and Generation API methods like [`lmql.generate`](#lmql-generate) and [`lmql.score`](#lmql-score) functions.
+Sets the model to be used when no `from` clause or `@lmql.query(model=<model>)` are specified in LMQL. The default model applies globally in the current process and affects both LMQL queries and Generation API methods like [`lmql.generate`](#lmqlgenerate) and [`lmql.score`](#lmqlscore) functions.
 
 You can also specify the environment variable `LMQL_DEFAULT_MODEL` to set the default model.

--- a/docs/docs/models/hf.md
+++ b/docs/docs/models/hf.md
@@ -7,7 +7,7 @@ LMQL relies on a two-process architecture: The inference process (long-running) 
 
 This architecture is advantageous for locally-hosted models, as the model loading time can be quite long or the required GPU hardware might not even be available on the client machine. 
 
-This chapter first discusses how to use of the two-process inference API, and then presents an alternative on how to leverage [In-Process Model Loading](#in-process-model-loading), which avoids the need for a separate server process within the same architecture.
+This chapter first discusses how to use of the two-process inference API, and then presents an alternative on how to leverage [In-Process Model Loading](#in-process-models), which avoids the need for a separate server process within the same architecture.
 
 ![Inference Architecture](./inference.svg)
 
@@ -26,7 +26,7 @@ By default, this exposes an [LMQL/LMTP inference API](https://github.com/eth-sri
 
 ### Configuration
 
-**Endpoint and Port** By default, models will be served via port `8080`. To change this, you can specify the port via the `--port` option of the `lmql serve-model` command. On the client side, to connect to a model server running on a different port, you can specify the port when constructing an [`lmql.model`](../lib/generations.md#lmql-llm-objects) object:
+**Endpoint and Port** By default, models will be served via port `8080`. To change this, you can specify the port via the `--port` option of the `lmql serve-model` command. On the client side, to connect to a model server running on a different port, you can specify the port when constructing an [`lmql.model`](../lib/generations.md#lmqlllm-objects) object:
 
 ```python
 lmql.model("gpt2", endpoint="localhost:9999")

--- a/docs/features/3-models.md
+++ b/docs/features/3-models.md
@@ -7,15 +7,15 @@ LMQL automatically makes your LLM code portable across several backends. You can
 
 
 <div class="cards">
-    <a href="../docs/models/llama.cpp.html">
+    <a href="../docs/models/llama.cpp.md">
         <span style="font-size: 3.0em;">🦙</span>
         <h1>llama.cpp</h1>
     </a>
-    <a href="../docs/models/openai.html">
+    <a href="../docs/models/openai.md">
         <img src="/openai.svg" alt="OpenAI" class="invert"/>
         <h1>OpenAI</h1>
     </a>
-    <a href="../docs/models/hf.html">
+    <a href="../docs/models/hf.md">
         <span style="font-size: 3.0em;">🤗</span>
         <h1>Transformers</h1>
     </a>


### PR DESCRIPTION
Fixes broken links / anchors in the documents

This is described further in issue #302

Here is a list of all of the broken links I have caught thus far. This is by no means an exhaustive list.

# lmql/docs/docs/language/reference.md

Broken anchors in the `reference.md` file

- [ ] #python-api -- don't know how to fix this
- [x] #legacy-syntax
- [x] #modern-syntax

# lmql/docs/features/3-models.md

Broken link in the `3-models.md` file

- [x] ../docs/models/llama.cpp.html --
- [x] ../docs/models/openai.html
- [x] ../docs/models/hf.html

# lmql/docs/docs/models/hf.md

Broken anchor / link in the `hf.md` file

- [x] #in-process-model-loading
- [x] ../lib/generations.md#lmql-llm-objects

# lmql/docs/docs/lib/generations.md

Broken anchors in the `generations.md` file

- [x] #lmql-generate
- [x] #lmql-score
- [x] #lmql-set_default_model
- [x] #llm-generate_sync
- [x] #llm-generate
- [x] #llm-score-sync
- [x] #llm-score