### PR TITLE
Explicitly use python3

### DIFF
--- a/src/lmql/ui/live/live.js
+++ b/src/lmql/ui/live/live.js
@@ -37,8 +37,8 @@ io.on('connection', s => {
     const app_input = request.app_input;
     const app_arguments = request.app_arguments;
     
-    // run "python live.py endpoints" and get output lines as array
-    execFile(`python`, [`live.py`, `endpoints`, app_name], (err, stdout, stderr) => {
+    // run "python3 live.py endpoints" and get output lines as array
+    execFile(`python3`, [`live.py`, `endpoints`, app_name], (err, stdout, stderr) => {
         if (err) {
             console.log(err);
             s.emit("app-error", stdout + stderr)
@@ -95,7 +95,7 @@ app.get('/app/:app_name', (req, res) => {
   res.setHeader('Cache-Control', 'no-cache, no-store, must-revalidate');
   let html = fs.readFileSync(path.join(content_dir, 'index.html'), {encoding: 'utf8'})
   
-  execFile(`python`, [`live.py`, `client-html`, app_name], (err, stdout, stderr) => {
+  execFile(`python3`, [`live.py`, `client-html`, app_name], (err, stdout, stderr) => {
     if (err) {
         console.log(err);
         res.send(html.replace("<<<CLIENT_HTML>>>", "Failed to load app html for app."))
@@ -108,8 +108,8 @@ app.get('/app/:app_name', (req, res) => {
 // serve /app/<app_name>
 app.get('/app/:app_name/app-client.js', (req, res) => {
   const app_name = req.params.app_name;
-  // run "python live.py endpoints" and get output lines as array
-  execFile(`python`, [`live.py`, `client-script`, app_name], (err, stdout, stderr) => {
+  // run "python3 live.py endpoints" and get output lines as array
+  execFile(`python3`, [`live.py`, `client-script`, app_name], (err, stdout, stderr) => {
     if (err) {
         console.log(err);
         res.send("")
@@ -144,15 +144,15 @@ let running_processes = {}
 function run_app(app_name, app_input, app_arguments, socket) {
     const app_input_as_json = JSON.stringify(app_input);
     const app_arguments_as_json = JSON.stringify(app_arguments);
-    // run "python live.py endpoints" and get output lines as array
-    // console.log(" >", `python live.py ${app_name} ${app_input_as_json}`);
+    // run "python3 live.py endpoints" and get output lines as array
+    // console.log(" >", `python3 live.py ${app_name} ${app_input_as_json}`);
     
     if (!app_input) {
       socket.emit("app-exit", `Error: Cannot run app with empty input\n`)
       return;
     }
 
-    const live_process = spawn('python', ['live.py', app_name, app_input_as_json, app_arguments_as_json]);
+    const live_process = spawn('python3', ['live.py', app_name, app_input_as_json, app_arguments_as_json]);
     // app input escape all double quotes as twice
     let input = app_input.replace(/"/g, '\\"');
 


### PR DESCRIPTION
### The Issue

The Node backend makes system calls to `python`, but this symlink is not available on e.g. a fresh install of Ubuntu/WSL2.

On such a system it is still possible to install lmql and run `lmql playground`, but as soon as you hit 'Run', you'll get
```
Compiled successfully!

You can now view web in the browser.

  Local:            http://localhost:3000
  On Your Network:  http://172.20.20.84:3000

Note that the development build is not optimized.
To create a production build, use yarn build.

webpack compiled successfully
Error: spawn python ENOENT
    at ChildProcess._handle.onexit (node:internal/child_process:286:19)
    at onErrorNT (node:internal/child_process:484:16)
    at process.processTicksAndRejections (node:internal/process/task_queues:82:21) {
  errno: -2,
  code: 'ENOENT',
  syscall: 'spawn python',
  path: 'python',
  spawnargs: [ 'live.py', 'endpoints', 'lmql' ],
  cmd: 'python live.py endpoints lmql'
}
```

I suspect the reason this wasn't caught earlier is that installing conda creates a `python` symlink. So very few developers would encounter this issue.

### The Solution
Simply replace all OS calls to `python` with `python3`.