### PR TITLE
Fix MANIFEST.in for proper build

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,12 +1,9 @@
-include src/lmql/ui/*
-recursive-include src/lmql/ui/playground/ *
-<<<<<<< HEAD
-=======
-recursive-exclude src/lmql/ui/playground/build/ *
->>>>>>> a231d6cbbb15091ac273a309f36b8c9d5f5b6c89
-recursive-include src/lmql/lib/chat/assets/ *
-recursive-include src/lmql/ui/live/ *
-recursive-exclude src/lmql/ui/live/node_modules/ *
-recursive-exclude src/lmql/ui/live/ *.tokens
-recursive-exclude src/lmql/ui/playground/node_modules/ *
-recursive-exclude src/lmql/ui/vscode/ *
+include src/lmql/ui *
+recursive-include src/lmql/ui/playground *
+recursive-exclude src/lmql/ui/playground/build *
+recursive-exclude src/lmql/ui/playground/node_modules *
+recursive-include src/lmql/lib/chat/assets *
+recursive-include src/lmql/ui/live *
+recursive-exclude src/lmql/ui/live/node_modules *
+recursive-exclude src/lmql/ui/live *.tokens
+recursive-exclude src/lmql/ui/vscode *


### PR DESCRIPTION
Fixes an unresolved merge conflict in MANIFEST.in and removes trailing slashes so local building also works on Windows

Should likely be tested on Linux, but works on WSL