### PR TITLE
Dataclass list handling

### DIFF
--- a/src/lmql/lib/types.py
+++ b/src/lmql/lib/types.py
@@ -164,7 +164,7 @@ async def is_type(ty, description=False):
                 indent += ""
                 stack = [(k, "dict-item", key_type[k], existing_value.get(k)) for k in key_type.keys()] + ["DEDENT", f"}}{line_end}"] + stack
             elif type(key_type) is list:
-                "["
+                "[["
                 existing_value = existing_value or []
                 indent += ""
                 stack = [("", "list-item", key_type[0], (0, existing_value))] + ["DEDENT", f"]{line_end}"] + stack


### PR DESCRIPTION
Closes #185.
Fix as per [0xc1c4da's suggestion](https://github.com/eth-sri/lmql/issues/185#issuecomment-1684894262)

Handles a bug where lists do not begin with a "[" in json, resulting in malformed json objects.